### PR TITLE
Test migration to Sui Move's 2024 (alpha) edition

### DIFF
--- a/ramm-misc/Move.lock
+++ b/ramm-misc/Move.lock
@@ -31,3 +31,8 @@ dependencies = [
   { name = "MoveStdlib" },
   { name = "Sui" },
 ]
+
+[move.toolchain-version]
+compiler-version = "1.19.1"
+edition = "legacy"
+flavor = "sui"

--- a/ramm-sui-deploy/Cargo.lock
+++ b/ramm-sui-deploy/Cargo.lock
@@ -1144,6 +1144,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "consensus-config"
+version = "0.1.0"
+dependencies = [
+ "fastcrypto",
+ "mysten-network",
+ "rand",
+ "serde",
+ "shared-crypto",
+ "workspace-hack",
+]
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3039,7 @@ dependencies = [
  "petgraph",
  "regex",
  "serde",
+ "stacker",
  "tempfile",
 ]
 
@@ -3359,6 +3372,7 @@ dependencies = [
  "futures",
  "http",
  "multiaddr",
+ "pin-project-lite",
  "serde",
  "snap",
  "tokio",
@@ -4179,6 +4193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -5255,6 +5278,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5451,7 +5487,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.18.0"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5474,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.18.0"
+version = "1.19.1"
 dependencies = [
  "bcs",
  "schemars",
@@ -5535,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.18.0"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5591,6 +5627,7 @@ dependencies = [
  "bcs",
  "bincode",
  "byteorder",
+ "consensus-config",
  "derivative",
  "derive_more",
  "enum_dispatch",

--- a/ramm-sui/Move.lock
+++ b/ramm-sui/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 0
-manifest_digest = "C38B0A789416AADBCC8558671B942576B831C3E0D0837DEB1A19A250FA0F15AA"
+manifest_digest = "A58C4DBBBBFB6082AB1CA78C64AAB0617451D817CFCF4CA6EDCDEDC14002E878"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 
 dependencies = [
@@ -31,3 +31,8 @@ dependencies = [
   { name = "MoveStdlib" },
   { name = "Sui" },
 ]
+
+[move.toolchain-version]
+compiler-version = "1.19.1"
+edition = "legacy"
+flavor = "sui"

--- a/ramm-sui/Move.toml
+++ b/ramm-sui/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ramm_sui"
 version = "0.0.1"
+edition = "2024.alpha"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet" }

--- a/ramm-sui/sources/events.move
+++ b/ramm-sui/sources/events.move
@@ -136,35 +136,6 @@ module ramm_sui::events {
         )
     }
 
-    /// Datatype used to emit, to the Sui blockchain, information on a failed liquidity deposit.
-    ///
-    /// This could occur when e.g. the RAMM has no issued tokens for an asset, or no balance
-    /// with which to satisfy the redemption.
-    struct LiquidityDepositFailureEvent has copy, drop {
-        ramm_id: ID,
-        trader: address,
-        token_in: TypeName,
-        amount_in: u64,
-    }
-
-    /// Given all the information necessary to identify a given RAMM's failed liquidity deposit event,
-    /// emit it.
-    public(friend) fun liquidity_deposit_failure_event(
-        ramm_id: ID,
-        trader: address,
-        token_in: TypeName,
-        amount_in: u64,
-    ) {
-        event::emit(
-            LiquidityDepositFailureEvent {
-                ramm_id,
-                trader,
-                token_in,
-                amount_in,
-            }
-        )
-    }
-
     /// Datatype used to emit, to the Sui blockchain, information on a successful liquidity deposit.
     struct LiquidityDepositEvent has copy, drop {
         ramm_id: ID,

--- a/ramm-sui/sources/events.move
+++ b/ramm-sui/sources/events.move
@@ -27,7 +27,7 @@ module ramm_sui::events {
     As such, they are defined here.
     */
 
-    struct PoolStateEvent has copy, drop {
+    public struct PoolStateEvent has copy, drop {
         ramm_id: ID,
         sender: address,
         asset_types: vector<TypeName>,
@@ -54,16 +54,16 @@ module ramm_sui::events {
     }
 
     /// Phantom type to mark a `TradeEvent` as the result of `trade_amount_in`
-    struct TradeIn {}
+    public struct TradeIn {}
     /// Phantom type to mark a `TradeEvent` as the result of `trade_amount_out`
-    struct TradeOut {}
+    public struct TradeOut {}
 
     /// Datatype used to emit, to the Sui blockchain, information on a successful trade.
     ///
     /// A phantom type is used to mark whether it's the result of a call to `trade_amount_in`
     /// (selling an exact amount of an asset to the RAMM), or to `trade_amount_out` (buying
     /// an exact amount of an asset from the RAMM).
-    struct TradeEvent<phantom TradeType> has copy, drop {
+    public struct TradeEvent<phantom TradeType> has copy, drop {
         ramm_id: ID,
         trader: address,
         token_in: TypeName,
@@ -105,7 +105,7 @@ module ramm_sui::events {
     /// A phantom type is used to mark whether it's the result of a call to `trade_amount_in`
     /// (selling an exact amount of an asset to the RAMM), or to `trade_amount_out` (buying
     /// an exact amount of an asset from the RAMM).
-    struct TradeFailure<phantom TradeType> has copy, drop {
+    public struct TradeFailure<phantom TradeType> has copy, drop {
         ramm_id: ID,
         trader: address,
         token_in: TypeName,
@@ -137,7 +137,7 @@ module ramm_sui::events {
     }
 
     /// Datatype used to emit, to the Sui blockchain, information on a successful liquidity deposit.
-    struct LiquidityDepositEvent has copy, drop {
+    public struct LiquidityDepositEvent has copy, drop {
         ramm_id: ID,
         trader: address,
         token_in: TypeName,
@@ -166,7 +166,7 @@ module ramm_sui::events {
     }
 
     /// Datatype describing a Sui event for a given RAMM's liquidity withdrawal.
-    struct LiquidityWithdrawalEvent has copy, drop {
+    public struct LiquidityWithdrawalEvent has copy, drop {
         ramm_id: ID,
         trader: address,
         token_out: TypeName,
@@ -198,7 +198,7 @@ module ramm_sui::events {
     }
 
     /// Datatype describing a Sui event for a given RAMM's fee collection.
-    struct FeeCollectionEvent has copy, drop {
+    public struct FeeCollectionEvent has copy, drop {
         ramm_id: ID,
         admin: address,
         fee_collector: address,

--- a/ramm-sui/sources/interface2.move
+++ b/ramm-sui/sources/interface2.move
@@ -77,9 +77,9 @@ module ramm_sui::interface2 {
         ramm::check_trade_amount_in<AssetIn>(self, (coin::value(&amount_in) as u256));
 
         let current_timestamp: u64 = clock::timestamp_ms(clock);
-        let new_prices = vec_map::empty<u8, u256>();
-        let factors_for_prices = vec_map::empty<u8, u256>();
-        let new_price_timestamps = vec_map::empty<u8, u64>();
+        let mut new_prices = vec_map::empty<u8, u256>();
+        let mut factors_for_prices = vec_map::empty<u8, u256>();
+        let mut new_price_timestamps = vec_map::empty<u8, u64>();
         ramm::check_feed_and_get_price_data(
             self,
             current_timestamp,
@@ -159,7 +159,7 @@ module ramm_sui::interface2 {
         let amount_out_u64: u64 = (amount_out_u256 as u64);
             if (ramm::execute(&trade)) {
                 if (amount_out_u64 >= min_ao) {
-                let amount_in: Balance<AssetIn> = coin::into_balance(amount_in);
+                let mut amount_in: Balance<AssetIn> = coin::into_balance(amount_in);
 
                 let fee: u64 = (ramm::protocol_fee(&trade) as u64);
                 let fee_bal: Balance<AssetIn> = balance::split(&mut amount_in, fee);
@@ -230,9 +230,9 @@ module ramm_sui::interface2 {
         ramm::check_trade_amount_out<AssetOut>(self, (amount_out as u256));
 
         let current_timestamp: u64 = clock::timestamp_ms(clock);
-        let new_prices = vec_map::empty<u8, u256>();
-        let factors_for_prices = vec_map::empty<u8, u256>();
-        let new_price_timestamps = vec_map::empty<u8, u64>();
+        let mut new_prices = vec_map::empty<u8, u256>();
+        let mut factors_for_prices = vec_map::empty<u8, u256>();
+        let mut new_price_timestamps = vec_map::empty<u8, u64>();
         ramm::check_feed_and_get_price_data(
             self,
             current_timestamp,
@@ -305,8 +305,8 @@ module ramm_sui::interface2 {
         let max_ai_u64: u64 = coin::value(&max_ai);
         if (ramm::execute(&trade)) {
             if (trade_amount <= max_ai_u64) {
-                let max_ai: Balance<AssetIn> = coin::into_balance(max_ai);
-                let amount_in: Balance<AssetIn> = balance::split(&mut max_ai, trade_amount);
+                let mut max_ai: Balance<AssetIn> = coin::into_balance(max_ai);
+                let mut amount_in: Balance<AssetIn> = balance::split(&mut max_ai, trade_amount);
                 let remainder = max_ai;
 
                 let fee: u64 = (ramm::protocol_fee(&trade) as u64);
@@ -375,9 +375,9 @@ module ramm_sui::interface2 {
         let oth = ramm::get_asset_index<Other>(self);
 
         let current_timestamp: u64 = clock::timestamp_ms(clock);
-        let new_prices = vec_map::empty<u8, u256>();
-        let factors_for_prices = vec_map::empty<u8, u256>();
-        let new_price_timestamps = vec_map::empty<u8, u64>();
+        let mut new_prices = vec_map::empty<u8, u256>();
+        let mut factors_for_prices = vec_map::empty<u8, u256>();
+        let mut new_price_timestamps = vec_map::empty<u8, u64>();
         ramm::check_feed_and_get_price_data(
             self,
             current_timestamp,
@@ -493,9 +493,9 @@ module ramm_sui::interface2 {
         let o   = ramm::get_asset_index<AssetOut>(self);
 
         let current_timestamp: u64 = clock::timestamp_ms(clock);
-        let new_prices = vec_map::empty<u8, u256>();
-        let factors_for_prices = vec_map::empty<u8, u256>();
-        let new_price_timestamps = vec_map::empty<u8, u64>();
+        let mut new_prices = vec_map::empty<u8, u256>();
+        let mut factors_for_prices = vec_map::empty<u8, u256>();
+        let mut new_price_timestamps = vec_map::empty<u8, u64>();
         ramm::check_feed_and_get_price_data(
             self,
             current_timestamp,
@@ -526,7 +526,7 @@ module ramm_sui::interface2 {
             self, snd, *vec_map::get(&new_prices, &snd), *vec_map::get(&new_price_timestamps, &snd)
         );
 
-        let volatility_fees: VecMap<u8, u256> = vec_map::empty();
+        let mut volatility_fees: VecMap<u8, u256> = vec_map::empty();
         vec_map::insert(&mut volatility_fees, fst, fst_vol_fee);
         vec_map::insert(&mut volatility_fees, snd, snd_vol_fee);
         /*
@@ -581,7 +581,7 @@ module ramm_sui::interface2 {
         };
 
         let burn_amount: u64 = (*lpt_amount as u64);
-        let lp_token: Balance<LP<AssetOut>> = coin::into_balance(lp_token);
+        let mut lp_token: Balance<LP<AssetOut>> = coin::into_balance(lp_token);
         let burn_tokens: Balance<LP<AssetOut>> = balance::split(&mut lp_token, burn_amount);
         // Update RAMM's untyped count of LP tokens for outgoing asset
         ramm::decr_lptokens_issued<AssetOut>(self, burn_amount);
@@ -621,8 +621,8 @@ module ramm_sui::interface2 {
 
         // Build required data structures for liquidity withdrawal event emission.
 
-        let amounts_out_u64: VecMap<TypeName, u64> = vec_map::empty();
-        let fees_u64: VecMap<TypeName, u64> = vec_map::empty();
+        let mut amounts_out_u64: VecMap<TypeName, u64> = vec_map::empty();
+        let mut fees_u64: VecMap<TypeName, u64> = vec_map::empty();
         vec_map::insert(&mut amounts_out_u64, type_name::get<Asset1>(), (*vec_map::get(&amounts_out, &fst) as u64));
         vec_map::insert(&mut fees_u64, type_name::get<Asset1>(), (*vec_map::get(&fees, &fst) as u64));
         if (vec_map::contains(&amounts_out, &snd)) {
@@ -667,7 +667,7 @@ module ramm_sui::interface2 {
         let value_fst: u64 = coin::value(&fst);
         let value_snd: u64 = coin::value(&snd);
 
-        let collected_fees: VecMap<TypeName, u64> = vec_map::empty();
+        let mut collected_fees: VecMap<TypeName, u64> = vec_map::empty();
         vec_map::insert(&mut collected_fees, type_name::get<Asset1>(), value_fst);
         vec_map::insert(&mut collected_fees, type_name::get<Asset2>(), value_snd);
 

--- a/ramm-sui/sources/interface2.move
+++ b/ramm-sui/sources/interface2.move
@@ -1,7 +1,6 @@
 /// Public interface for 2-asset RAMMs.
 module ramm_sui::interface2 {
     use std::type_name::{Self, TypeName};
-    use std::string;
 
     use sui::balance::{Self, Balance};
     use sui::clock::{Self, Clock};

--- a/ramm-sui/sources/interface2.move
+++ b/ramm-sui/sources/interface2.move
@@ -37,8 +37,9 @@ module ramm_sui::interface2 {
     const ETradeCouldNotBeExecuted: u64 = 7;
     const ETradeAmountTooSmall: u64 = 8;
     const ENotAdmin: u64 = 9;
-    const ELiqWthdrwLPTBurn: u64 = 10;
-    const EInvalidWithdrawal: u64 = 11;
+    const ELiqDepYieldedNoLPTokens: u64 = 10;
+    const ELiqWthdrwLPTBurn: u64 = 11;
+    const EInvalidWithdrawal: u64 = 12;
 
     /// Trading function for a RAMM with two (2) assets.
     ///
@@ -438,12 +439,7 @@ module ramm_sui::interface2 {
         */
 
         if (lpt == 0) {
-            let amount_in_u64: u64 = coin::value(&amount_in);
-            transfer::public_transfer(amount_in, tx_context::sender(ctx));
-
-            events::liquidity_deposit_failure_event(
-                ramm::get_id(self), tx_context::sender(ctx), type_name::get<AssetIn>(), amount_in_u64
-            );
+            abort ELiqDepYieldedNoLPTokens
         } else {
             let amount_in_u64: u64 = coin::value(&amount_in);
             let amount_in: Balance<AssetIn> = coin::into_balance(amount_in);

--- a/ramm-sui/sources/interface2.move
+++ b/ramm-sui/sources/interface2.move
@@ -340,29 +340,10 @@ module ramm_sui::interface2 {
                 }
             } else {
                 // In this case, `trade.execute` is true, but `trade.amount > max_ai`
-                transfer::public_transfer(max_ai, tx_context::sender(ctx));
-
-                events::trade_failure_event<TradeOut>(
-                    ramm::get_id(self),
-                    tx_context::sender(ctx),
-                    type_name::get<AssetIn>(),
-                    type_name::get<AssetOut>(),
-                    max_ai_u64,
-                    string::utf8(b"Trade not executed due to slippage tolerance.")
-                );
+                abort ESlippageToleranceExceeded
             }
         } else {
-            transfer::public_transfer(max_ai, tx_context::sender(ctx));
-
-            events::trade_failure_event<TradeOut>(
-                ramm::get_id(self),
-                tx_context::sender(ctx),
-                type_name::get<AssetIn>(),
-                type_name::get<AssetOut>(),
-                max_ai_u64,
-                ramm::message(&trade)
-            );
-        
+            abort ETradeCouldNotBeExecuted
         };
 
         ramm::check_ramm_invariants_2<AssetIn, AssetOut>(self);

--- a/ramm-sui/sources/interface3.move
+++ b/ramm-sui/sources/interface3.move
@@ -41,6 +41,7 @@ module ramm_sui::interface3 {
     const EInvalidWithdrawal: u64 = 12;
 
     /// Trading function for a RAMM with three (3) assets.
+    ///
     /// Used to deposit a given amount of asset `T_i`, in exchange for asset `T_o`.
     ///
     /// # Aborts
@@ -79,9 +80,9 @@ module ramm_sui::interface3 {
         let oth = ramm::get_asset_index<Other>(self);
 
         let current_timestamp: u64 = clock::timestamp_ms(clock);
-        let new_prices = vec_map::empty<u8, u256>();
-        let factors_for_prices = vec_map::empty<u8, u256>();
-        let new_price_timestamps = vec_map::empty<u8, u64>();
+        let mut new_prices = vec_map::empty<u8, u256>();
+        let mut factors_for_prices = vec_map::empty<u8, u256>();
+        let mut new_price_timestamps = vec_map::empty<u8, u64>();
         ramm::check_feed_and_get_price_data(
             self,
             current_timestamp,
@@ -182,7 +183,7 @@ module ramm_sui::interface3 {
         let amount_out_u64: u64 = (amount_out_u256 as u64);
         if (ramm::execute(&trade)) {
             if (amount_out_u64 >= min_ao) {
-                let amount_in: Balance<AssetIn> = coin::into_balance(amount_in);
+                let mut amount_in: Balance<AssetIn> = coin::into_balance(amount_in);
 
                 let fee: u64 = (ramm::protocol_fee(&trade) as u64);
                 let fee_bal: Balance<AssetIn> = balance::split(&mut amount_in, fee);
@@ -257,9 +258,9 @@ module ramm_sui::interface3 {
         ramm::check_trade_amount_out<AssetOut>(self, (amount_out as u256));
 
         let current_timestamp: u64 = clock::timestamp_ms(clock);
-        let new_prices = vec_map::empty<u8, u256>();
-        let factors_for_prices = vec_map::empty<u8, u256>();
-        let new_price_timestamps = vec_map::empty<u8, u64>();
+        let mut new_prices = vec_map::empty<u8, u256>();
+        let mut factors_for_prices = vec_map::empty<u8, u256>();
+        let mut new_price_timestamps = vec_map::empty<u8, u64>();
         ramm::check_feed_and_get_price_data(
             self,
             current_timestamp,
@@ -359,8 +360,8 @@ module ramm_sui::interface3 {
         let max_ai_u64: u64 = coin::value(&max_ai);
         if (ramm::execute(&trade)) {
             if (trade_amount <= max_ai_u64) {
-                let max_ai: Balance<AssetIn> = coin::into_balance(max_ai);
-                let amount_in: Balance<AssetIn> = balance::split(&mut max_ai, trade_amount);
+                let mut max_ai: Balance<AssetIn> = coin::into_balance(max_ai);
+                let mut amount_in: Balance<AssetIn> = balance::split(&mut max_ai, trade_amount);
                 let remainder = max_ai;
 
                 let fee: u64 = (ramm::protocol_fee(&trade) as u64);
@@ -431,9 +432,9 @@ module ramm_sui::interface3 {
         let anoth = ramm::get_asset_index<Another>(self);
 
         let current_timestamp: u64 = clock::timestamp_ms(clock);
-        let new_prices = vec_map::empty<u8, u256>();
-        let factors_for_prices = vec_map::empty<u8, u256>();
-        let new_price_timestamps = vec_map::empty<u8, u64>();
+        let mut new_prices = vec_map::empty<u8, u256>();
+        let mut factors_for_prices = vec_map::empty<u8, u256>();
+        let mut new_price_timestamps = vec_map::empty<u8, u64>();
         ramm::check_feed_and_get_price_data(
             self,
             current_timestamp,
@@ -579,9 +580,9 @@ module ramm_sui::interface3 {
         let o   = ramm::get_asset_index<AssetOut>(self);
 
         let current_timestamp: u64 = clock::timestamp_ms(clock);
-        let new_prices = vec_map::empty<u8, u256>();
-        let factors_for_prices = vec_map::empty<u8, u256>();
-        let new_price_timestamps = vec_map::empty<u8, u64>();
+        let mut new_prices = vec_map::empty<u8, u256>();
+        let mut factors_for_prices = vec_map::empty<u8, u256>();
+        let mut new_price_timestamps = vec_map::empty<u8, u64>();
         ramm::check_feed_and_get_price_data(
             self,
             current_timestamp,
@@ -624,7 +625,7 @@ module ramm_sui::interface3 {
             self, trd, *vec_map::get(&new_prices, &trd), *vec_map::get(&new_price_timestamps, &trd)
         );
 
-        let volatility_fees: VecMap<u8, u256> = vec_map::empty();
+        let mut volatility_fees: VecMap<u8, u256> = vec_map::empty();
         vec_map::insert(&mut volatility_fees, fst, fst_vol_fee);
         vec_map::insert(&mut volatility_fees, snd, snd_vol_fee);
         vec_map::insert(&mut volatility_fees, trd, trd_vol_fee);
@@ -686,7 +687,7 @@ module ramm_sui::interface3 {
         };
 
         let burn_amount: u64 = (*lpt_amount as u64);
-        let lp_token: Balance<LP<AssetOut>> = coin::into_balance(lp_token);
+        let mut lp_token: Balance<LP<AssetOut>> = coin::into_balance(lp_token);
         let burn_tokens: Balance<LP<AssetOut>> = balance::split(&mut lp_token, burn_amount);
         // Update RAMM's untyped count of LP tokens for outgoing asset
         ramm::decr_lptokens_issued<AssetOut>(self, burn_amount);
@@ -734,8 +735,8 @@ module ramm_sui::interface3 {
 
         // Build required data structures for liquidity withdrawal event emission.
 
-        let amounts_out_u64: VecMap<TypeName, u64> = vec_map::empty();
-        let fees_u64: VecMap<TypeName, u64> = vec_map::empty();
+        let mut amounts_out_u64: VecMap<TypeName, u64> = vec_map::empty();
+        let mut fees_u64: VecMap<TypeName, u64> = vec_map::empty();
         vec_map::insert(&mut amounts_out_u64, type_name::get<Asset1>(), (*vec_map::get(&amounts_out, &fst) as u64));
         vec_map::insert(&mut fees_u64, type_name::get<Asset1>(), (*vec_map::get(&fees, &fst) as u64));
         if (vec_map::contains(&amounts_out, &snd)) {
@@ -788,7 +789,7 @@ module ramm_sui::interface3 {
         let value_snd: u64 = coin::value(&snd);
         let value_trd: u64 = coin::value(&trd);
 
-        let collected_fees: VecMap<TypeName, u64> = vec_map::empty();
+        let mut collected_fees: VecMap<TypeName, u64> = vec_map::empty();
         vec_map::insert(&mut collected_fees, type_name::get<Asset1>(), value_fst);
         vec_map::insert(&mut collected_fees, type_name::get<Asset2>(), value_snd);
         vec_map::insert(&mut collected_fees, type_name::get<Asset3>(), value_trd);

--- a/ramm-sui/sources/interface3.move
+++ b/ramm-sui/sources/interface3.move
@@ -357,63 +357,47 @@ module ramm_sui::interface3 {
         let trade_amount = (ramm::amount(&trade) as u64);
 
         let max_ai_u64: u64 = coin::value(&max_ai);
-        if (ramm::execute(&trade) && trade_amount <= max_ai_u64) {
-            let max_ai: Balance<AssetIn> = coin::into_balance(max_ai);
-            let amount_in: Balance<AssetIn> = balance::split(&mut max_ai, trade_amount);
-            let remainder = max_ai;
+        if (ramm::execute(&trade)) {
+            if (trade_amount <= max_ai_u64) {
+                let max_ai: Balance<AssetIn> = coin::into_balance(max_ai);
+                let amount_in: Balance<AssetIn> = balance::split(&mut max_ai, trade_amount);
+                let remainder = max_ai;
 
-            let fee: u64 = (ramm::protocol_fee(&trade) as u64);
-            let fee_bal: Balance<AssetIn> = balance::split(&mut amount_in, fee);
-            ramm::join_protocol_fees(self, i, fee_bal);
+                let fee: u64 = (ramm::protocol_fee(&trade) as u64);
+                let fee_bal: Balance<AssetIn> = balance::split(&mut amount_in, fee);
+                ramm::join_protocol_fees(self, i, fee_bal);
 
-            ramm::join_bal(self, i, (balance::value(&amount_in) as u256));
-            ramm::join_typed_bal(self, i, amount_in);
+                ramm::join_bal(self, i, (balance::value(&amount_in) as u256));
+                ramm::join_typed_bal(self, i, amount_in);
 
-            ramm::split_bal(self, o, (amount_out as u256));
-            let amnt_out: Balance<AssetOut> = ramm::split_typed_bal(self, o, amount_out);
-            let amnt_out: Coin<AssetOut> = coin::from_balance(amnt_out, ctx);
-            transfer::public_transfer(amnt_out, tx_context::sender(ctx));
+                ramm::split_bal(self, o, (amount_out as u256));
+                let amnt_out: Balance<AssetOut> = ramm::split_typed_bal(self, o, amount_out);
+                let amnt_out: Coin<AssetOut> = coin::from_balance(amnt_out, ctx);
+                transfer::public_transfer(amnt_out, tx_context::sender(ctx));
 
-            events::trade_event<TradeOut>(
-                ramm::get_id(self),
-                tx_context::sender(ctx),
-                type_name::get<AssetIn>(),
-                type_name::get<AssetOut>(),
-                trade_amount,
-                amount_out,
-                fee,
-                ramm::execute(&trade)
-            );
+                events::trade_event<TradeOut>(
+                    ramm::get_id(self),
+                    tx_context::sender(ctx),
+                    type_name::get<AssetIn>(),
+                    type_name::get<AssetOut>(),
+                    trade_amount,
+                    amount_out,
+                    fee,
+                    ramm::execute(&trade)
+                );
 
-            if (balance::value(&remainder) > 0) {
-                let remainder: Coin<AssetIn> = coin::from_balance(remainder, ctx);
-                transfer::public_transfer(remainder, tx_context::sender(ctx));
+                if (balance::value(&remainder) > 0) {
+                    let remainder: Coin<AssetIn> = coin::from_balance(remainder, ctx);
+                    transfer::public_transfer(remainder, tx_context::sender(ctx));
+                } else {
+                    balance::destroy_zero(remainder);
+                }
             } else {
-                balance::destroy_zero(remainder);
+                // In this case, `trade.execute` is true, but `trade.amount > max_ai`
+                abort ESlippageToleranceExceeded
             }
-        } else if (!ramm::execute(&trade)) {
-            transfer::public_transfer(max_ai, tx_context::sender(ctx));
-
-            events::trade_failure_event<TradeOut>(
-                ramm::get_id(self),
-                tx_context::sender(ctx),
-                type_name::get<AssetIn>(),
-                type_name::get<AssetOut>(),
-                max_ai_u64,
-                ramm::message(&trade)
-            );
-        // In this case, `trade.execute` is true, but `trade.amount > max_ai`
         } else {
-            transfer::public_transfer(max_ai, tx_context::sender(ctx));
-
-            events::trade_failure_event<TradeOut>(
-                ramm::get_id(self),
-                tx_context::sender(ctx),
-                type_name::get<AssetIn>(),
-                type_name::get<AssetOut>(),
-                max_ai_u64,
-                string::utf8(b"Trade not executed due to slippage tolerance.")
-            );
+            abort ETradeCouldNotBeExecuted
         };
 
         ramm::check_ramm_invariants_3<AssetIn, AssetOut, Other>(self);

--- a/ramm-sui/sources/interface3.move
+++ b/ramm-sui/sources/interface3.move
@@ -1,7 +1,6 @@
 /// Public interface for 3-asset RAMMs.
 module ramm_sui::interface3 {
     use std::type_name::{Self, TypeName};
-    use std::string;
 
     use sui::balance::{Self, Balance};
     use sui::clock::{Self, Clock};

--- a/ramm-sui/sources/interface3.move
+++ b/ramm-sui/sources/interface3.move
@@ -37,8 +37,9 @@ module ramm_sui::interface3 {
     const ETradeCouldNotBeExecuted: u64 = 7;
     const ETradeAmountTooSmall: u64 = 8;
     const ENotAdmin: u64 = 9;
-    const ELiqWthdrwLPTBurn: u64 = 10;
-    const EInvalidWithdrawal: u64 = 11;
+    const ELiqDepYieldedNoLPTokens: u64 = 10;
+    const ELiqWthdrwLPTBurn: u64 = 11;
+    const EInvalidWithdrawal: u64 = 12;
 
     /// Trading function for a RAMM with three (3) assets.
     /// Used to deposit a given amount of asset `T_i`, in exchange for asset `T_o`.
@@ -522,15 +523,7 @@ module ramm_sui::interface3 {
         */
 
         if (lpt == 0) {
-            let amount_in_u64: u64 = coin::value(&amount_in);
-            transfer::public_transfer(amount_in, tx_context::sender(ctx));
-
-            events::liquidity_deposit_failure_event(
-                ramm::get_id(self),
-                tx_context::sender(ctx),
-                type_name::get<AssetIn>(),
-                amount_in_u64
-            );
+            abort ELiqDepYieldedNoLPTokens
         } else {
             let amount_in_u64: u64 = coin::value(&amount_in);
             let amount_in: Balance<AssetIn> = coin::into_balance(amount_in);

--- a/ramm-sui/sources/math.move
+++ b/ramm-sui/sources/math.move
@@ -51,7 +51,9 @@ module ramm_sui::math {
     ///
     /// If the calculation overflows.
     public fun pow(base: u256, exp: u8): u256 {
-        let res = 1;
+        let mut base = base;
+        let mut exp = exp;
+        let mut res = 1;
         while (exp >= 1) {
             if (exp % 2 == 0) {
                 base = base * base;
@@ -131,8 +133,9 @@ module ramm_sui::math {
         assert!(n <= 127, EPowNExponentTooLarge);
         assert!(x <= max, EPowNBaseTooLarge);
 
-        let result: u256 = one;
-        let a: u256 = x;
+        let mut result: u256 = one;
+        let mut a: u256 = x;
+        let mut n = n;
 
         while (n != 0) {
             if (n % 2 == 1) {
@@ -160,15 +163,15 @@ module ramm_sui::math {
         assert!(67 * pow <= x && x <= 150 * pow, EPowDBaseOutOfBounds);
         assert!(a < one, EPowDExpTooLarge);
 
-        let result: u256 = one;
-        let n: u256 = 0;
-        let tn: u256 = one;
-        let sign: bool = true;
+        let mut result: u256 = one;
+        let mut n: u256 = 0;
+        let mut tn: u256 = one;
+        let mut sign: bool = true;
         let iters = 30;
 
         while (n < iters) {
-            let _factor1: u256 = 0;
-            let _factor2: u256 = 0;
+            let mut _factor1: u256 = 0;
+            let mut _factor2: u256 = 0;
 
             if (a >= n * one) {
                 _factor1 = a - n * one;
@@ -237,16 +240,16 @@ module ramm_sui::math {
         prec: u8,
         max_prec: u8,
     ): VecMap<u8, u256> {
-        let _W = vec_map::empty<u8, u256>();
-        let _B: u256 = 0;
-        let i: u8 = 0;
+        let mut _W = vec_map::empty<u8, u256>();
+        let mut _B: u256 = 0;
+        let mut i: u8 = 0;
         let _N = (vec_map::size(balances) as u8);
         while (i < _N) {
             vec_map::insert(&mut _W, i, 0u256);
             i = i + 1;
         };
 
-        let j: u8 = 0;
+        let mut j: u8 = 0;
         while (j < _N) {
             let w_j = vec_map::get_mut(&mut _W, &j);
             *w_j = mul(
@@ -258,7 +261,7 @@ module ramm_sui::math {
             j = j + 1;
         };
 
-        let k: u8 = 0;
+        let mut k: u8 = 0;
         while (k < _N) {
             let w_k = vec_map::get_mut(&mut _W, &k);
             *w_k = div(*w_k, _B, prec, max_prec);
@@ -281,11 +284,11 @@ module ramm_sui::math {
         prec: u8,
         max_prec: u8,
     ): (u256, u256) {
-        let _B: u256 = 0;
-        let _L: u256 = 0;
+        let mut _B: u256 = 0;
+        let mut _L: u256 = 0;
 
         let _N = (vec_map::size(balances) as u8);
-        let j: u8 = 0;
+        let mut j: u8 = 0;
         while (j < _N) {
             let price_j = *vec_map::get(prices, &j) * *vec_map::get(factors_for_prices, &j);
             _B = _B + mul(price_j, *vec_map::get(balances, &j) * *vec_map::get(factors_for_balances, &j), prec, max_prec);
@@ -321,10 +324,10 @@ module ramm_sui::math {
             max_prec,
         );
 
-        let imbs = vec_map::empty();
+        let mut imbs = vec_map::empty();
 
         let _N = (vec_map::size(balances) as u8);
-        let j: u8 = 0;
+        let mut j: u8 = 0;
         while (j < _N) {
             if (*vec_map::get(lp_tokens_issued, &j) != 0) {
                 let val = div(
@@ -370,10 +373,10 @@ module ramm_sui::math {
     ): bool {
         let _N = (vec_map::size(balances) as u8);
 
-        let balances_before = vec_map::empty<u8, u256>();
-        let balances_after = vec_map::empty<u8, u256>();
+        let mut balances_before = vec_map::empty<u8, u256>();
+        let mut balances_after = vec_map::empty<u8, u256>();
 
-        let k = 0;
+        let mut k = 0;
         while (k < _N) {
             let balance_current = *vec_map::get(balances, &k);
             vec_map::insert(&mut balances_before, k, balance_current);
@@ -490,14 +493,14 @@ module ramm_sui::math {
 
             // Sui Move doesn't support negative numbers, so the below check is required
             // to avoid aborting the program when performing the subtraction
-            let price_change: u256;
+            let mut price_change: u256;
             if (new_price >= previous_price) {
                 price_change = (new_price - previous_price) * one / previous_price;
             } else {
                 price_change = (previous_price - new_price) * one / previous_price;
             };
 
-            let price_change_param: u256;
+            let mut price_change_param: u256;
             if (price_change > maximum_tolerable_change) {
                 price_change_param = price_change;
             } else {
@@ -549,7 +552,7 @@ module ramm_sui::math {
         let current_volatility_param: u256 = *stored_volatility_param;
         let current_volatility_timestamp: u64 = *stored_volatility_timestamp;
 
-        let price_change: u256;
+        let mut price_change: u256;
 
         // If the previously recorded price is 0, this is the first volatility index calculation
         // for this asset; it is undefined, so 0 is chosen.

--- a/ramm-sui/sources/ramm.move
+++ b/ramm-sui/sources/ramm.move
@@ -576,7 +576,7 @@ These would not work:
         use sui::test_scenario;
 
         let admin = @0xA1;
-        let scenario_val = test_scenario::begin(admin);
+        let mut scenario_val = test_scenario::begin(admin);
         let scenario = &mut scenario_val;
         {
             new_ramm(admin, test_scenario::ctx(scenario));

--- a/ramm-sui/sources/ramm.move
+++ b/ramm-sui/sources/ramm.move
@@ -1962,9 +1962,9 @@ work well together
         let _W: VecMap<u8, u256> = weights(self, &new_prices, &factors_for_prices);
         let wi: u256 = *vec_map::get(&_W, &i);
         let wo: u256 = *vec_map::get(&_W, &o);
-        let leverage: &mut u256;
+        let leverage: &mut u256 = &mut 0;
         *leverage = BASE_LEVERAGE;
-        let trading_fee: &mut u256;
+        let trading_fee: &mut u256 = &mut 0;
         *trading_fee = BASE_FEE;
 
         if (get_typed_lptok_issued<AssetOut>(self, o) != 0 && get_typed_bal<AssetIn>(self, i) != 0) {
@@ -2048,10 +2048,10 @@ work well together
 
         let _W: VecMap<u8, u256> = weights(self, &prices, &factors_for_prices);
         let wi: u256 = *vec_map::get(&_W, &i);
-        let wo: u256 = *vec_map::get(&_W, &o)
-        let leverage: &mut u256;
+        let wo: u256 = *vec_map::get(&_W, &o);
+        let leverage: &mut u256 = &mut 0;
         *leverage = BASE_LEVERAGE;
-        let trading_fee: &mut u256;
+        let trading_fee: &mut u256 = &mut 0;
         *trading_fee = BASE_FEE;
 
         if (get_typed_lptok_issued<AssetOut>(self, o) != 0 && get_typed_bal<AssetIn>(self, i) != 0) {

--- a/ramm-sui/sources/ramm.move
+++ b/ramm-sui/sources/ramm.move
@@ -103,13 +103,13 @@ module ramm_sui::ramm {
     /// of a liquidity provider.
     ///
     /// The parameter `Asset` is for the coin held in the pool.
-    struct LP<phantom Asset> has drop, store {}
+    public struct LP<phantom Asset> has drop, store {}
 
     /// Admin capability to circumvent restricted actions on the RAMM pool:
     /// * transfer RAMM protocol fees out of the pool,
     /// * enable/disable deposits for a certain asset
     /// * etc.
-    struct RAMMAdminCap has key { id: UID }
+    public struct RAMMAdminCap has key { id: UID }
 
     /// Transfer a RAMM's admin capability to another address.
     ///
@@ -140,7 +140,7 @@ module ramm_sui::ramm {
     /// function like `transfer_admin_cap`, and it does not have `store` either.
     /// This is by design, as it is not intended for a RAMM to be created and remain without assets
     /// for long, and disallowing transfer of this cap disincentivizes delays.
-    struct RAMMNewAssetCap has key { id: UID }
+    public struct RAMMNewAssetCap has key { id: UID }
 
     /// RAMM data structure, allows
     /// * adding/removing liquidity for one of its assets
@@ -171,7 +171,7 @@ module ramm_sui::ramm {
     /// any further operations.
     ///
     /// See this repository's README for more information.
-    struct RAMM has key {
+    public struct RAMM has key {
         // UID of a `RAMM` object. Required for `RAMM` to have the `key` ability,
         // and ergo become a shared object.
         id: UID,
@@ -313,7 +313,7 @@ These would not work:
     ///   as well as the fee to be levied on the inbound asset
     /// * in the case of an asset withdrawal, the amount of the inbound asset is specified,
     ///   as well as the fee to be levied on the inbound asset
-    struct TradeOutput has drop {
+    public struct TradeOutput has drop {
         amount: u256,
         protocol_fee: u256,
         execute_trade: bool,
@@ -359,7 +359,7 @@ These would not work:
     /// * the value of liquidity withdrawal fee applied to each asset, 0.4% of the amount
     /// * the total value of the redeemed tokens
     /// * the remaining value
-    struct WithdrawalOutput has drop {
+    public struct WithdrawalOutput has drop {
         amounts: VecMap<u8, u256>,
         fees: VecMap<u8, u256>,
         value: u256,
@@ -441,7 +441,7 @@ These would not work:
     ///
     /// These data are required to use PTBs to then interact with the created RAMM,
     /// using the API in this module.
-    struct NewRAMMIDs has copy, drop {
+    public struct NewRAMMIDs has copy, drop {
         ramm_id: ID,
         admin_cap_id: ID,
         new_asset_cap_id: ID,
@@ -766,7 +766,7 @@ work well together
             ERAMMInvalidInitState
         );
 
-        let ix = 0;
+        let mut ix = 0;
         while ({
             // This loop invariant is trivial, but it is needed to prove below that
             // if this function terminates, it does not change the RAMM's asset count.
@@ -1569,9 +1569,9 @@ work well together
         // The vectors can't be `copy`ed, `vec_map::values` does not exist, and
         // `vec_map::into_keys_values` shouldn't be used, as by traversing the balance vectors, it
         // is certain the balances will be in the correct order.
-        let i = 0;
-        let asset_balances: vector<u256> = vector::empty();
-        let asset_lpt_issued: vector<u256> = vector::empty();
+        let mut i = 0;
+        let mut asset_balances: vector<u256> = vector::empty();
+        let mut asset_lpt_issued: vector<u256> = vector::empty();
         while (i < self.asset_count) {
             vector::push_back(&mut asset_balances, get_bal(self, i));
             vector::push_back(&mut asset_lpt_issued, get_lptok_issued(self, i));
@@ -2152,20 +2152,20 @@ work well together
     ): WithdrawalOutput {
         let lpt: u256 = (lpt as u256);
 
-        let amounts_out = vec_map::empty<u8, u256>();
+        let mut amounts_out = vec_map::empty<u8, u256>();
         // Required to initialize this `VecMap` to zeroes, or `liquidity_withdrawal`
         // will fail.
-        let t: u8 = 0;
+        let mut t: u8 = 0;
         while (t < get_asset_count(self)) {
             vec_map::insert(&mut amounts_out, t, 0);
             t = t + 1;
         };
-        let fees: VecMap<u8, u256> = copy amounts_out;
+        let mut fees: VecMap<u8, u256> = copy amounts_out;
 
         let a_remaining: &mut u256 = &mut 0;
         let factor_o: u256 = get_fact_for_bal(self, o);
         let bo: u256 = get_typed_bal<AssetOut>(self, o) * factor_o;
-        let imb_ratios: VecMap<u8, u256> = imbalance_ratios(self, &prices, &factors_for_prices);
+        let mut imb_ratios: VecMap<u8, u256> = imbalance_ratios(self, &prices, &factors_for_prices);
         let ao: &mut u256 = &mut 0;
         let (_B, _L): (u256, u256) = compute_B_and_L(self, &prices, &factors_for_prices);
 
@@ -2243,12 +2243,12 @@ work well together
 
         // Potential case: withdrawal continued with different tokens
         *vec_map::get_mut(&mut imb_ratios, &o) = 0;
-        let j: u8 = 0;
+        let mut j: u8 = 0;
         while (j < get_asset_count(self)) {
             let max_imb_ratio: &mut u256 = &mut 0;
             let index: &mut u8 = &mut copy o;
 
-            let l: u8 = 0;
+            let mut l: u8 = 0;
             while (l < get_asset_count(self)) {
                 if (*max_imb_ratio < *vec_map::get(&imb_ratios, &l)) {
                     *index = l;

--- a/ramm-sui/sources/ramm.move
+++ b/ramm-sui/sources/ramm.move
@@ -1962,8 +1962,10 @@ work well together
         let _W: VecMap<u8, u256> = weights(self, &new_prices, &factors_for_prices);
         let wi: u256 = *vec_map::get(&_W, &i);
         let wo: u256 = *vec_map::get(&_W, &o);
-        let leverage: &mut u256 = &mut BASE_LEVERAGE;
-        let trading_fee: &mut u256 = &mut BASE_FEE;
+        let leverage: &mut u256;
+        *leverage = BASE_LEVERAGE;
+        let trading_fee: &mut u256;
+        *trading_fee = BASE_FEE;
 
         if (get_typed_lptok_issued<AssetOut>(self, o) != 0 && get_typed_bal<AssetIn>(self, i) != 0) {
             let imbs = imbalance_ratios(self, &new_prices, &factors_for_prices);
@@ -2046,9 +2048,11 @@ work well together
 
         let _W: VecMap<u8, u256> = weights(self, &prices, &factors_for_prices);
         let wi: u256 = *vec_map::get(&_W, &i);
-        let wo: u256 = *vec_map::get(&_W, &o);
-        let leverage: &mut u256 = &mut BASE_LEVERAGE;
-        let trading_fee: &mut u256 = &mut BASE_FEE;
+        let wo: u256 = *vec_map::get(&_W, &o)
+        let leverage: &mut u256;
+        *leverage = BASE_LEVERAGE;
+        let trading_fee: &mut u256;
+        *trading_fee = BASE_FEE;
 
         if (get_typed_lptok_issued<AssetOut>(self, o) != 0 && get_typed_bal<AssetIn>(self, i) != 0) {
             let imbs = imbalance_ratios(self, &prices, &factors_for_prices);

--- a/ramm-sui/tests/interface2_oracle_safety_tests.move
+++ b/ramm-sui/tests/interface2_oracle_safety_tests.move
@@ -42,13 +42,13 @@ module ramm_sui::interface2_oracle_safety_tests {
     #[test]
     #[expected_failure(abort_code = oracles::EStalePrice)]
     fun trade_amount_in_2_stale_aggregator_price() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
-            let clock = test_scenario::take_shared<Clock>(scenario);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut clock = test_scenario::take_shared<Clock>(scenario);
             let btc_amount: u64 = (1 * test_util::btc_factor() as u64);
             let amount_in = coin::mint_for_testing<BTC>(btc_amount, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -78,13 +78,13 @@ module ramm_sui::interface2_oracle_safety_tests {
     #[test]
     #[expected_failure(abort_code = oracles::EStalePrice)]
     fun trade_amount_out_2_stale_aggregator_price() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
-            let clock = test_scenario::take_shared<Clock>(scenario);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut clock = test_scenario::take_shared<Clock>(scenario);
             let btc_amount: u64 = (1 * test_util::btc_factor() as u64);
             let max_amount_in = coin::mint_for_testing<BTC>(btc_amount, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -114,13 +114,13 @@ module ramm_sui::interface2_oracle_safety_tests {
     #[test]
     #[expected_failure(abort_code = oracles::EStalePrice)]
     fun liquidity_deposit_2_stale_aggregator_price() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
-            let clock = test_scenario::take_shared<Clock>(scenario);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut clock = test_scenario::take_shared<Clock>(scenario);
             let btc_amount: u64 = (1 * test_util::btc_factor() as u64);
             let amount_in = coin::mint_for_testing<BTC>(btc_amount, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -150,13 +150,13 @@ module ramm_sui::interface2_oracle_safety_tests {
     #[expected_failure(abort_code = oracles::EStalePrice)]
     fun liquidity_withdrawal_2_zero_deposit() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
-            let clock = test_scenario::take_shared<Clock>(scenario);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut clock = test_scenario::take_shared<Clock>(scenario);
 
             let lp_btc_amount: u64 = (1 * test_util::btc_factor() as u64);
             let lp_tokens = coin::mint_for_testing<LP<BTC>>(lp_btc_amount, test_scenario::ctx(scenario));

--- a/ramm-sui/tests/interface2_safety_tests.move
+++ b/ramm-sui/tests/interface2_safety_tests.move
@@ -56,12 +56,12 @@ module ramm_sui::interface2_safety_tests {
     #[expected_failure(abort_code = interface2::ERAMMInvalidSize)]
     /// Check that calling `trade_amount_in_2` on a RAMM without *exactly* 2 assets fails.
     fun trade_amount_in_2_invalid_ramm_size() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, _, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, _, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<BTC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -69,7 +69,7 @@ module ramm_sui::interface2_safety_tests {
 
             interface2::trade_amount_in_2<BTC, ETH>(
                 &mut alice_ramm,
-                                &clock,
+                &clock,
                 amount_in,
                 0,
                 &btc_aggr,
@@ -93,12 +93,12 @@ module ramm_sui::interface2_safety_tests {
     /// This test *must* fail.
     fun trade_amount_in_2_invalid_asset() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<USDC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -106,7 +106,7 @@ module ramm_sui::interface2_safety_tests {
 
             interface2::trade_amount_in_2<USDC, ETH>(
                 &mut alice_ramm,
-                                &clock,
+                &clock,
                 amount_in,
                 0,
                 &btc_aggr,
@@ -130,12 +130,12 @@ module ramm_sui::interface2_safety_tests {
     /// This *must* fail.
     fun trade_amount_in_2_insufficient_amount_in() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val)
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val)
             = test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<ETH>(999, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -168,12 +168,12 @@ module ramm_sui::interface2_safety_tests {
     /// This test *must* fail.
     fun trade_amount_in_2_no_minted_lptoken() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<BTC>(1 * (test_util::btc_factor() as u64), test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -204,18 +204,18 @@ module ramm_sui::interface2_safety_tests {
     ///
     /// This *must* fail.
     fun trade_amount_in_2_insufficient_outbound_balance() {
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
             vec_map::insert(&mut initial_asset_liquidity, 0, 1000);
             vec_map::insert(&mut initial_asset_liquidity, 1, 0);
             vec_map::insert(&mut initial_asset_liquidity, 2, 0);
 
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
                 test_util::create_ramm_test_scenario_btc_eth(ALICE, initial_asset_liquidity);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -246,12 +246,12 @@ module ramm_sui::interface2_safety_tests {
     /// for the inbound asset will fail.
     fun trade_amount_in_2_excessive_amount_in() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -284,12 +284,12 @@ module ramm_sui::interface2_safety_tests {
     /// for the outbound asset will fail.
     fun trade_amount_in_2_excessive_amount_out() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -325,12 +325,12 @@ module ramm_sui::interface2_safety_tests {
     /// This *must* fail.
     fun trade_amount_in_2_invalid_aggregator() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -365,12 +365,12 @@ module ramm_sui::interface2_safety_tests {
     #[expected_failure(abort_code = interface2::ERAMMInvalidSize)]
     /// Check that calling `trade_amount_out_2` on a RAMM without *exactly* 2 assets fails.
     fun trade_amount_out_2_invalid_ramm_size() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, _, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, _, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let max_amount_in = coin::mint_for_testing<BTC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -402,12 +402,12 @@ module ramm_sui::interface2_safety_tests {
     /// This test *must* fail.
     fun trade_amount_out_2_invalid_asset() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let max_amount_in = coin::mint_for_testing<USDC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -439,12 +439,12 @@ module ramm_sui::interface2_safety_tests {
     /// This *must* fail.
     fun trade_amount_out_2_insufficient_amount_in() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val)
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val)
             = test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             // Recall that `create_ramm_2_test_scenario_with_liquidity_in` sets a 0.001 ETH
             // minimum trade amount, and that this ETH has 8 decimal places of precision
@@ -479,12 +479,12 @@ module ramm_sui::interface2_safety_tests {
     /// This test *must* fail.
     fun trade_amount_out_2_no_minted_lptoken() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let max_amount_in = coin::mint_for_testing<BTC>(1 * (test_util::btc_factor() as u64), test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -515,18 +515,18 @@ module ramm_sui::interface2_safety_tests {
     ///
     /// This *must* fail.
     fun trade_amount_out_2_insufficient_outbound_balance() {
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
             vec_map::insert(&mut initial_asset_liquidity, 0, 1000);
             vec_map::insert(&mut initial_asset_liquidity, 1, 0);
             vec_map::insert(&mut initial_asset_liquidity, 2, 0);
 
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
                 test_util::create_ramm_test_scenario_btc_eth(ALICE, initial_asset_liquidity);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -557,12 +557,12 @@ module ramm_sui::interface2_safety_tests {
     /// for the outbound asset will fail.
     fun trade_amount_out_2_excessive_amount_out() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -593,12 +593,12 @@ module ramm_sui::interface2_safety_tests {
     /// for the inbound asset will fail.
     fun trade_amount_out_2_excessive_amount_in() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -632,12 +632,12 @@ module ramm_sui::interface2_safety_tests {
     /// This *must* fail.
     fun trade_amount_out_2_invalid_aggregator() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -673,12 +673,12 @@ module ramm_sui::interface2_safety_tests {
     /// This *must* fail.
     fun trade_amount_out_2_balance_empty_balance_with_circ_lp_tokens() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -715,12 +715,12 @@ module ramm_sui::interface2_safety_tests {
     #[expected_failure(abort_code = interface2::ERAMMInvalidSize)]
     /// Check that calling `liquidity_deposit_2` on a RAMM without *exactly* 2 assets fails.
     fun liquidity_deposit_2_invalid_ramm_size() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, _, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, _, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<BTC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -751,12 +751,12 @@ module ramm_sui::interface2_safety_tests {
     /// This test *must* fail.
     fun liquidity_deposit_2_invalid_asset() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<USDC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -787,12 +787,12 @@ module ramm_sui::interface2_safety_tests {
     /// This test *must* fail.
     fun liquidity_deposit_2_zero_deposit() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<BTC>(0, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -823,12 +823,12 @@ module ramm_sui::interface2_safety_tests {
     /// This *must* fail.
     fun liquidity_deposit_2_invalid_aggregator() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -862,12 +862,12 @@ module ramm_sui::interface2_safety_tests {
     #[expected_failure(abort_code = interface2::ERAMMInvalidSize)]
     /// Check that calling `liquidity_withdrawal_2` on a RAMM without *exactly* 2 assets fails.
     fun liquidity_withdrawal_2_invalid_ramm_size() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, _, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, _, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let lp_token = coin::mint_for_testing<LP<BTC>>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -898,12 +898,12 @@ module ramm_sui::interface2_safety_tests {
     /// This test *must* fail.
     fun liquidity_withdrawal_2_invalid_asset() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let lp_tokens = coin::mint_for_testing<LP<USDC>>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -934,12 +934,12 @@ module ramm_sui::interface2_safety_tests {
     /// This *must* fail.
     fun liquidity_withdrawal_2_invalid_aggregator() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -972,12 +972,12 @@ module ramm_sui::interface2_safety_tests {
     /// This test *must* fail.
     fun liquidity_withdrawal_2_zero_deposit() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let lp_tokens = coin::mint_for_testing<LP<BTC>>(0, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -1013,12 +1013,12 @@ module ramm_sui::interface2_safety_tests {
     #[expected_failure(abort_code = interface2::ERAMMInvalidSize)]
     /// Check that calling `collect_fees_2` on a RAMM without *exactly* 2 assets fails.
     fun collect_fees_2_invalid_ramm_size() {
-        let (alice_ramm_id, _, _, _, scenario_val) =
+        let (alice_ramm_id, _, _, _, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ALICE);
 
@@ -1044,7 +1044,7 @@ module ramm_sui::interface2_safety_tests {
     /// It *must* fail.
     fun collect_fees_2_wrong_admin_cap() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, _, _, scenario_val) = test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
+        let (alice_ramm_id, _, _, mut scenario_val) = test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
         let scenario = &mut scenario_val;
         
         test_scenario::next_tx(scenario, BOB);
@@ -1056,7 +1056,7 @@ module ramm_sui::interface2_safety_tests {
         test_scenario::next_tx(scenario, ALICE);
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let bob_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, BOB);
 

--- a/ramm-sui/tests/interface2_tests.move
+++ b/ramm-sui/tests/interface2_tests.move
@@ -27,7 +27,7 @@ module ramm_sui::interface2_tests {
     /// 2. Next, a redemption of every LPETH token by a provider
     /// 3. Finally, a redemption of every LPUSDT token by a provider
     fun liquidity_withdrawal_2_test() {
-        let (ramm_id, eth_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         // First part of the test: a trader, Alice, wishes to buy 20 ETH
@@ -36,7 +36,7 @@ module ramm_sui::interface2_tests {
         test_scenario::next_tx(scenario, ALICE);
 
         let (total_usdt, usdt_trade_fees) : (u256, u256) = {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
@@ -115,7 +115,7 @@ module ramm_sui::interface2_tests {
         test_scenario::next_tx(scenario, ADMIN);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
@@ -163,7 +163,7 @@ module ramm_sui::interface2_tests {
 
         let collected_usdt_liquidity_withdrawal_fees: u256 =
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
@@ -220,7 +220,7 @@ module ramm_sui::interface2_tests {
     ///   protocol fees from this trade, and 0 of any other asset.
     /// * futhermore, the RAMM's fees should be null after the collection
     fun collect_fees_2_test_1() {
-        let (ramm_id, eth_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         let eth_trade_amount: u64 = 10 * (test_util::eth_factor() as u64);
@@ -237,7 +237,7 @@ module ramm_sui::interface2_tests {
         // Trade: 10 ETH in, roughly 20k USDT out
         // The pool is fresh, so all imbalance ratios are 1
         let eth_trade_fee: u256 = {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
@@ -302,7 +302,7 @@ module ramm_sui::interface2_tests {
         // Next step: collect the RAMM fees to the collection address (in this case, the admin's)
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
 
             interface2::collect_fees_2<ETH, USDT>(
@@ -351,7 +351,7 @@ module ramm_sui::interface2_tests {
     ///   protocol fees from this withdrawal, and 0 of any other asset.
     /// * futhermore, the RAMM's fees should be null after the collection
     fun collect_fees_2_test_2() {
-        let (ramm_id, eth_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         let prec: u8 = test_util::eth_dec_places();
@@ -363,7 +363,7 @@ module ramm_sui::interface2_tests {
 
         // First step: the admin withdraws the ETH they've provided to the pool
         let (initial_eth_balance, initial_usdt_balance): (u256, u256) = {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
@@ -404,7 +404,7 @@ module ramm_sui::interface2_tests {
 
         // Second step: the admin performs the fee collection
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
 
             interface2::collect_fees_2<ETH, USDT>(

--- a/ramm-sui/tests/interface3_oracle_safety_tests.move
+++ b/ramm-sui/tests/interface3_oracle_safety_tests.move
@@ -42,13 +42,13 @@ module ramm_sui::interface3_oracle_safety_tests {
     #[test]
     #[expected_failure(abort_code = oracles::EStalePrice)]
     fun trade_amount_in_3_stale_aggregator_price() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
-            let clock = test_scenario::take_shared<Clock>(scenario);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut clock = test_scenario::take_shared<Clock>(scenario);
             let btc_amount: u64 = (1 * test_util::btc_factor() / 10as u64);
             let amount_in = coin::mint_for_testing<BTC>(btc_amount, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -81,13 +81,13 @@ module ramm_sui::interface3_oracle_safety_tests {
     #[test]
     #[expected_failure(abort_code = oracles::EStalePrice)]
     fun trade_amount_out_3_stale_aggregator_price() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
-            let clock = test_scenario::take_shared<Clock>(scenario);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut clock = test_scenario::take_shared<Clock>(scenario);
             let btc_amount: u64 = (1 * test_util::btc_factor() as u64);
             let max_amount_in = coin::mint_for_testing<BTC>(btc_amount, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -120,13 +120,13 @@ module ramm_sui::interface3_oracle_safety_tests {
     #[test]
     #[expected_failure(abort_code = oracles::EStalePrice)]
     fun liquidity_deposit_3_stale_aggregator_price() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
-            let clock = test_scenario::take_shared<Clock>(scenario);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut clock = test_scenario::take_shared<Clock>(scenario);
             let btc_amount: u64 = (1 * test_util::btc_factor() as u64);
             let amount_in = coin::mint_for_testing<BTC>(btc_amount, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -159,13 +159,13 @@ module ramm_sui::interface3_oracle_safety_tests {
     #[expected_failure(abort_code = oracles::EStalePrice)]
     fun liquidity_withdrawal_3_zero_deposit() {
         // Create a 2-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val) =
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val) =
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
-            let clock = test_scenario::take_shared<Clock>(scenario);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut clock = test_scenario::take_shared<Clock>(scenario);
 
             let lp_btc_amount: u64 = (1 * test_util::btc_factor() as u64);
             let lp_tokens = coin::mint_for_testing<LP<BTC>>(lp_btc_amount, test_scenario::ctx(scenario));

--- a/ramm-sui/tests/interface3_safety_tests.move
+++ b/ramm-sui/tests/interface3_safety_tests.move
@@ -57,11 +57,11 @@ module ramm_sui::interface3_safety_tests {
     #[expected_failure(abort_code = interface3::ERAMMInvalidSize)]
     /// Check that calling `trade_amount_in_3` on a RAMM without *exactly* 3 assets fails.
     fun trade_amount_in_3_invalid_ramm_size() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val)= test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val)= test_util::create_ramm_test_scenario_btc_eth_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<BTC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -94,12 +94,12 @@ module ramm_sui::interface3_safety_tests {
     /// This test *must* fail.
     fun trade_amount_in_3_invalid_asset() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<USDC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -134,12 +134,12 @@ module ramm_sui::interface3_safety_tests {
     /// This *must* fail.
     fun trade_amount_in_3_insufficient_amount_in() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)
             = test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<ETH>(999, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -175,12 +175,12 @@ module ramm_sui::interface3_safety_tests {
     /// This test *must* fail.
     fun trade_amount_in_3_no_minted_lptoken() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<BTC>(1 * (test_util::btc_factor() as u64), test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -214,18 +214,18 @@ module ramm_sui::interface3_safety_tests {
     ///
     /// This *must* fail.
     fun trade_amount_in_3_insufficient_outbound_balance() {
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
             vec_map::insert(&mut initial_asset_liquidity, 0, 1000);
             vec_map::insert(&mut initial_asset_liquidity, 1, 0);
             vec_map::insert(&mut initial_asset_liquidity, 2, 0);
 
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
                 test_util::create_ramm_test_scenario_btc_eth_sol(ALICE, initial_asset_liquidity);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -259,12 +259,12 @@ module ramm_sui::interface3_safety_tests {
     /// for the inbound asset will fail.
     fun trade_amount_in_3_excessive_amount_in() {
         // Create a 3-asset pool with BTC, ETH
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -300,12 +300,12 @@ module ramm_sui::interface3_safety_tests {
     /// for the outbound asset will fail.
     fun trade_amount_in_3_excessive_amount_out() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -344,12 +344,12 @@ module ramm_sui::interface3_safety_tests {
     /// This *must* fail.
     fun trade_amount_in_3_invalid_aggregator() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -387,11 +387,11 @@ module ramm_sui::interface3_safety_tests {
     #[expected_failure(abort_code = interface3::ERAMMInvalidSize)]
     /// Check that calling `trade_amount_out_3` on a RAMM without *exactly* 3 assets fails.
     fun trade_amount_out_3_invalid_ramm_size() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val)= test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val)= test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let max_amount_in = coin::mint_for_testing<BTC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -424,12 +424,12 @@ module ramm_sui::interface3_safety_tests {
     /// This test *must* fail.
     fun trade_amount_out_3_invalid_asset() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let max_amount_in = coin::mint_for_testing<USDC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -464,12 +464,12 @@ module ramm_sui::interface3_safety_tests {
     /// This *must* fail.
     fun trade_amount_out_3_insufficient_amount_in() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)
             = test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             // Recall that `create_ramm_3_test_scenario_with_liquidity_in` sets a 0.001 ETH
             // minimum trade amount, and that this ETH has 8 decimal places of precision
@@ -507,12 +507,12 @@ module ramm_sui::interface3_safety_tests {
     /// This test *must* fail.
     fun trade_amount_out_3_no_minted_lptoken() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let max_amount_in = coin::mint_for_testing<BTC>(1 * (test_util::btc_factor() as u64), test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -546,18 +546,18 @@ module ramm_sui::interface3_safety_tests {
     ///
     /// This *must* fail.
     fun trade_amount_out_3_insufficient_outbound_balance() {
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
             vec_map::insert(&mut initial_asset_liquidity, 0, 1000);
             vec_map::insert(&mut initial_asset_liquidity, 1, 0);
             vec_map::insert(&mut initial_asset_liquidity, 2, 0);
 
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
                 test_util::create_ramm_test_scenario_btc_eth_sol(ALICE, initial_asset_liquidity);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -591,12 +591,12 @@ module ramm_sui::interface3_safety_tests {
     /// for the outbound asset will fail.
     fun trade_amount_out_3_excessive_amount_out() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -630,12 +630,12 @@ module ramm_sui::interface3_safety_tests {
     /// for the inbound asset will fail.
     fun trade_amount_out_3_excessive_amount_in() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -674,12 +674,12 @@ module ramm_sui::interface3_safety_tests {
     /// This *must* fail.
     fun trade_amount_out_3_invalid_aggregator() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -718,12 +718,12 @@ module ramm_sui::interface3_safety_tests {
     /// This *must* fail.
     fun trade_amount_out_3_balance_empty_balance_with_circ_lp_tokens() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -760,12 +760,12 @@ module ramm_sui::interface3_safety_tests {
     #[expected_failure(abort_code = interface3::ERAMMInvalidSize)]
     /// Check that calling `liquidity_deposit_3` on a RAMM without *exactly* 3 assets fails.
     fun liquidity_deposit_3_invalid_ramm_size() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<BTC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -797,12 +797,12 @@ module ramm_sui::interface3_safety_tests {
     /// This test *must* fail.
     fun liquidity_deposit_3_invalid_asset() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<USDC>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -836,12 +836,12 @@ module ramm_sui::interface3_safety_tests {
     /// This test *must* fail.
     fun liquidity_deposit_3_zero_deposit() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let amount_in = coin::mint_for_testing<BTC>(0, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -875,12 +875,12 @@ module ramm_sui::interface3_safety_tests {
     /// This *must* fail.
     fun liquidity_deposit_3_invalid_aggregator() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -917,11 +917,11 @@ module ramm_sui::interface3_safety_tests {
     #[expected_failure(abort_code = interface3::ERAMMInvalidSize)]
     /// Check that calling `liquidity_withdrawal_3` on a RAMM without *exactly* 3 assets fails.
     fun liquidity_withdrawal_3_invalid_ramm_size() {
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, scenario_val)= test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, mut scenario_val)= test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let lp_token = coin::mint_for_testing<LP<BTC>>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -953,12 +953,12 @@ module ramm_sui::interface3_safety_tests {
     /// This test *must* fail.
     fun liquidity_withdrawal_3_invalid_asset() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let lp_tokens = coin::mint_for_testing<LP<USDC>>(1000, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -992,12 +992,12 @@ module ramm_sui::interface3_safety_tests {
     /// This *must* fail.
     fun liquidity_withdrawal_3_invalid_aggregator() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
@@ -1033,12 +1033,12 @@ module ramm_sui::interface3_safety_tests {
     /// This test *must* fail.
     fun liquidity_withdrawal_3_zero_deposit() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val)=
+        let (alice_ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val)=
             test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let lp_tokens = coin::mint_for_testing<LP<BTC>>(0, test_scenario::ctx(scenario));
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
@@ -1077,11 +1077,11 @@ module ramm_sui::interface3_safety_tests {
     #[expected_failure(abort_code = interface3::ERAMMInvalidSize)]
     /// Check that calling `collect_fees_3` on a RAMM without *exactly* 3 assets fails.
     fun collect_fees_3_invalid_ramm_size() {
-        let (alice_ramm_id, _, _, scenario_val)= test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
+        let (alice_ramm_id, _, _, mut scenario_val)= test_util::create_ramm_test_scenario_btc_eth_no_liq(ALICE);
         let scenario = &mut scenario_val;
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ALICE);
 
@@ -1107,7 +1107,7 @@ module ramm_sui::interface3_safety_tests {
     /// It *must* fail.
     fun collect_fees_3_wrong_admin_cap() {
         // Create a 3-asset pool with BTC, ETH, SOL
-        let (alice_ramm_id, _, _, _, scenario_val)= test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
+        let (alice_ramm_id, _, _, _, mut scenario_val)= test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ALICE);
         let scenario = &mut scenario_val;
         
         test_scenario::next_tx(scenario, BOB);
@@ -1119,7 +1119,7 @@ module ramm_sui::interface3_safety_tests {
         test_scenario::next_tx(scenario, ALICE);
 
         {
-            let alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
+            let mut alice_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, alice_ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let bob_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, BOB);
 

--- a/ramm-sui/tests/interface3_tests.move
+++ b/ramm-sui/tests/interface3_tests.move
@@ -28,13 +28,13 @@ module ramm_sui::interface3_tests {
     /// asset the pool can provide.
     /// The trader receives no "change".
     fun trade_amount_in_3_test() {
-        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         test_scenario::next_tx(scenario, ALICE);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
@@ -137,7 +137,7 @@ module ramm_sui::interface3_tests {
         test_utils::assert_eq(test_scenario::num_user_events(&tx_fx), 0);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
@@ -185,13 +185,13 @@ module ramm_sui::interface3_tests {
     /// of an asset they desire, and provide an upper bound of the inbound asset,
     /// being returned the remainder.
     fun trade_amount_out_3_test() {
-        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         test_scenario::next_tx(scenario, BOB);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
@@ -277,7 +277,7 @@ module ramm_sui::interface3_tests {
     ///   protocol fees from this trade, and 0 of any other asset.
     /// * futhermore, the RAMM's fees should be null after the collection
     fun collect_fees_3_test_1() {
-        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         let eth_trade_amount: u64 = 10 * (test_util::eth_factor() as u64);
@@ -294,7 +294,7 @@ module ramm_sui::interface3_tests {
         // Trade: 10 ETH in, roughly 18k USDT out
         // The pool is fresh, so all imbalance ratios are 1
         let eth_trade_fee: u256 = {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
@@ -369,7 +369,7 @@ module ramm_sui::interface3_tests {
         // Next step: collect the RAMM fees to the collection address (in this case, the admin's)
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
 
             interface3::collect_fees_3<ETH, USDT, MATIC>(
@@ -386,7 +386,7 @@ module ramm_sui::interface3_tests {
         test_utils::assert_eq(test_scenario::num_user_events(&tx_fx), 1);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
 
             // Check that the RAMM has no fees to be collected
             test_utils::assert_eq(ramm::get_collected_protocol_fees<ETH>(&ramm), 0);
@@ -420,7 +420,7 @@ module ramm_sui::interface3_tests {
     ///   protocol fees from this withdrawal, and 0 of any other asset.
     /// * futhermore, the RAMM's fees should be null after the collection
     fun collect_fees_3_test_2() {
-        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         let prec: u8 = test_util::eth_dec_places();
@@ -432,7 +432,7 @@ module ramm_sui::interface3_tests {
 
         // First step: the admin withdraws the ETH they've provided to the pool
         let (initial_eth_balance, initial_matic_balance, initial_usdt_balance): (u256, u256, u256) = {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
@@ -477,7 +477,7 @@ module ramm_sui::interface3_tests {
 
         // Second step: the admin performs the fee collection
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
 
             interface3::collect_fees_3<ETH, USDT, MATIC>(

--- a/ramm-sui/tests/liquidity_provision_fees_tests.move
+++ b/ramm-sui/tests/liquidity_provision_fees_tests.move
@@ -76,7 +76,7 @@ module ramm_sui::liquidity_provision_fees_tests {
         admin_address: address,
         max_iterations: u64
     ) {
-        let (ramm_id, eth_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(admin_address);
+        let (ramm_id, eth_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(admin_address);
         let scenario = &mut scenario_val;
 
         test_scenario::next_tx(scenario, ALICE);
@@ -85,14 +85,14 @@ module ramm_sui::liquidity_provision_fees_tests {
         // printing the RAMM's balances after each trade, if the trade's ordinal is a power of two
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
 
             let eth_amnt = (10 * test_util::eth_factor() as u64);
             let usdt_amnt = (20_000 * test_util::usdt_factor() as u64);
-            let i: u64 = 1;
+            let mut i: u64 = 1;
             while (i <= max_iterations) {
                 let amount_in = coin::mint_for_testing<ETH>(eth_amnt, test_scenario::ctx(scenario));
                 interface2::trade_amount_in_2<ETH, USDT>(
@@ -140,7 +140,7 @@ module ramm_sui::liquidity_provision_fees_tests {
         test_scenario::next_tx(scenario, admin_address);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
@@ -200,7 +200,7 @@ module ramm_sui::liquidity_provision_fees_tests {
         test_scenario::next_tx(scenario, admin_address);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let admin_cap: RAMMAdminCap = test_scenario::take_from_address<RAMMAdminCap>(scenario, admin_address);
 
             interface2::collect_fees_2<ETH, USDT>(

--- a/ramm-sui/tests/math_tests.move
+++ b/ramm-sui/tests/math_tests.move
@@ -205,10 +205,10 @@ module ramm_sui::math_tests {
         prices_decimal_places: u8,
         balances_decimal_places: u8
     ): VecMap<u8, u256> {
-        let balances = vec_map::empty<u8, u256>();
-        let prices = vec_map::empty<u8, u256>();
-        let factors_prices = vec_map::empty<u8, u256>();
-        let factors_balances = vec_map::empty<u8, u256>();
+        let mut balances = vec_map::empty<u8, u256>();
+        let mut prices = vec_map::empty<u8, u256>();
+        let mut factors_prices = vec_map::empty<u8, u256>();
+        let mut factors_balances = vec_map::empty<u8, u256>();
 
         vec_map::insert(&mut balances, 0, bal_0);
         vec_map::insert(&mut prices, 0, 1_800_000_000_000);
@@ -279,11 +279,11 @@ module ramm_sui::math_tests {
         bal_2: u256,
         prices_decimal_places: u8,
     ): (VecMap<u8, u256>, VecMap<u8, u256>, VecMap<u8, u256>, VecMap<u8, u256>, VecMap<u8, u256>,) {
-        let balances = vec_map::empty<u8, u256>();
-        let lp_tokens_issued = vec_map::empty<u8, u256>();
-        let prices = vec_map::empty<u8, u256>();
-        let factors_prices = vec_map::empty<u8, u256>();
-        let factors_balances = vec_map::empty<u8, u256>();
+        let mut balances = vec_map::empty<u8, u256>();
+        let mut lp_tokens_issued = vec_map::empty<u8, u256>();
+        let mut prices = vec_map::empty<u8, u256>();
+        let mut factors_prices = vec_map::empty<u8, u256>();
+        let mut factors_balances = vec_map::empty<u8, u256>();
 
         vec_map::insert(&mut balances, 0, bal_0);
         vec_map::insert(&mut lp_tokens_issued, 0, 200 * test_util::eth_factor());
@@ -597,7 +597,7 @@ module ramm_sui::math_tests {
             MAX_PRECISION_DECIMAL_PLACES,
         );
 
-        let new_balances: VecMap<u8, u256> = copy prev_balances;
+        let mut new_balances: VecMap<u8, u256> = copy prev_balances;
         vec_map::remove(&mut new_balances, &i);
         vec_map::insert(&mut new_balances, i, new_eth);
         vec_map::remove(&mut new_balances, &o);
@@ -719,7 +719,7 @@ module ramm_sui::math_tests {
             MAX_PRECISION_DECIMAL_PLACES,
         );
 
-        let new_balances: VecMap<u8, u256> = copy prev_balances;
+        let mut new_balances: VecMap<u8, u256> = copy prev_balances;
         vec_map::remove(&mut new_balances, &i);
         vec_map::insert(&mut new_balances, i, new_eth);
         vec_map::remove(&mut new_balances, &o);
@@ -840,7 +840,7 @@ module ramm_sui::math_tests {
             MAX_PRECISION_DECIMAL_PLACES,
         );
 
-        let new_balances: VecMap<u8, u256> = copy prev_balances;
+        let mut new_balances: VecMap<u8, u256> = copy prev_balances;
         vec_map::remove(&mut new_balances, &i);
         vec_map::insert(&mut new_balances, i, new_usdt);
         vec_map::remove(&mut new_balances, &o);
@@ -964,7 +964,7 @@ module ramm_sui::math_tests {
             MAX_PRECISION_DECIMAL_PLACES,
         );
 
-        let new_balances: VecMap<u8, u256> = copy prev_balances;
+        let mut new_balances: VecMap<u8, u256> = copy prev_balances;
         vec_map::remove(&mut new_balances, &i);
         vec_map::insert(&mut new_balances, i, new_usdt);
         vec_map::remove(&mut new_balances, &o);
@@ -1070,7 +1070,7 @@ module ramm_sui::math_tests {
         let new_usdt = 27_418_571 * test_util::usdt_factor() / 100;
         let ao: u256 = prev_usdt - new_usdt;
 
-        let (balances, lp_tokens_issued, prices, factors_prices, factors_balances) =
+        let (mut balances, lp_tokens_issued, prices, factors_prices, factors_balances) =
             imbalance_ratios(prev_eth, 200_000 * test_util::matic_factor(), prev_usdt, 9);
 
         let before_imbs = ramm_math::imbalance_ratios(

--- a/ramm-sui/tests/ramm_tests.move
+++ b/ramm-sui/tests/ramm_tests.move
@@ -26,7 +26,7 @@ module ramm_sui::ramm_tests {
     ///   2b. Share aggregator objects
     /// 3. Initialize the RAMM
     fun create_ramm() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         // Check that the RAMM and caps don't yet exist before the RAMM's creation
@@ -53,7 +53,7 @@ module ramm_sui::ramm_tests {
          {
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
             let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ADMIN);
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
 
             let btc_aggr = test_scenario::take_shared<Aggregator>(scenario);
 
@@ -72,7 +72,7 @@ module ramm_sui::ramm_tests {
         // 2. initialize the RAMM, and
         // 3. check that the new_asset_cap used to add new objects no longer exists
         {
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
             let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ADMIN);
 
@@ -102,7 +102,7 @@ module ramm_sui::ramm_tests {
     /// 3. Add an asset (test BTC) to the RAMM
     /// 4. Verify the RAMM's internal state after the asset addition
     fun add_asset_to_ramm_tests() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         // Create the RAMM
@@ -120,7 +120,7 @@ module ramm_sui::ramm_tests {
          {
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
             let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ADMIN);
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
 
             let btc_aggr = test_scenario::take_shared<Aggregator>(scenario);
 
@@ -177,7 +177,7 @@ module ramm_sui::ramm_tests {
     /// 4. Initialize the RAMM
     /// 5. Verify that its deposits are now enabled, and nothing else in its internal state changed
     fun check_deposit_status_after_init() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         // Create RAMM
@@ -192,7 +192,7 @@ module ramm_sui::ramm_tests {
         test_scenario::next_tx(scenario, ADMIN);
 
         {
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
             let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ADMIN);
 
@@ -267,7 +267,7 @@ module ramm_sui::ramm_tests {
     ///
     /// Useful for the tests below.
     fun double_create(): (ID, ID, test_scenario::Scenario) {
-        let scenario_val = test_scenario::begin(ALICE);
+        let mut scenario_val = test_scenario::begin(ALICE);
         let scenario = &mut scenario_val;
 
         // Create first RAMM
@@ -297,11 +297,11 @@ module ramm_sui::ramm_tests {
     ///
     /// This *must* fail.
     fun add_asset_mismatched_admin_cap() {
-        let (_, bob_ramm_id, scenario_val) = double_create();
+        let (_, bob_ramm_id, mut scenario_val) = double_create();
         let scenario = &mut scenario_val;
 
         {
-            let bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
+            let mut bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
             let alice_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ALICE);
             let alice_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ALICE);
 
@@ -324,11 +324,11 @@ module ramm_sui::ramm_tests {
     ///
     /// This *must* fail.
     fun add_asset_mismatched_new_asset_cap() {
-        let (_, bob_ramm_id, scenario_val) = double_create();
+        let (_, bob_ramm_id, mut scenario_val) = double_create();
         let scenario = &mut scenario_val;
 
         {
-            let bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
+            let mut bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
             let bob_admin = test_scenario::take_from_address<RAMMAdminCap>(scenario, BOB);
             let alice_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ALICE);
 
@@ -352,7 +352,7 @@ module ramm_sui::ramm_tests {
         scenario: &mut test_scenario::Scenario
     ) {
         test_scenario::next_tx(scenario, sender);
-        let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+        let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
         let admin = test_scenario::take_from_address<RAMMAdminCap>(scenario, sender);
         let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, sender);
         let aggr = test_scenario::take_shared<Aggregator>(scenario);
@@ -369,7 +369,7 @@ module ramm_sui::ramm_tests {
     /// Create two test RAMMs with different owners, and then add the same asset
     /// to both.
     fun double_add_asset<Asset>(): (ID, ID, test_scenario::Scenario) {
-        let (alice_ramm_id, bob_ramm_id, scenario_val) = double_create();
+        let (alice_ramm_id, bob_ramm_id, mut scenario_val) = double_create();
         let scenario = &mut scenario_val;
 
         add_asset_to_ramm<Asset>(alice_ramm_id, ALICE, scenario);
@@ -385,11 +385,11 @@ module ramm_sui::ramm_tests {
     ///
     /// This *must* fail.
     fun initialize_mismatch_admin_cap() {
-        let (_alice_ramm_id, bob_ramm_id, scenario_val) = double_add_asset<BTC>();
+        let (_alice_ramm_id, bob_ramm_id, mut scenario_val) = double_add_asset<BTC>();
         let scenario = &mut scenario_val;
 
         {
-            let bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
+            let mut bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
             let alice_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ALICE);
             let alice_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ALICE);
 
@@ -409,11 +409,11 @@ module ramm_sui::ramm_tests {
     ///
     /// This *must* fail.
     fun initialize_mismatch_new_asset_cap() {
-        let (_alice_ramm_id, bob_ramm_id, scenario_val) = double_add_asset<BTC>();
+        let (_alice_ramm_id, bob_ramm_id, mut scenario_val) = double_add_asset<BTC>();
         let scenario = &mut scenario_val;
 
         {
-            let bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
+            let mut bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
             let bob_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, BOB);
             let alice_new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ALICE);
 
@@ -435,7 +435,7 @@ module ramm_sui::ramm_tests {
     ) {
         test_scenario::next_tx(scenario, sender);
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let admin = test_scenario::take_from_address<RAMMAdminCap>(scenario, sender);
             let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, sender);
             ramm::initialize_ramm(&mut ramm, &admin, new_asset_cap);
@@ -446,7 +446,7 @@ module ramm_sui::ramm_tests {
     }
 
     fun double_initialize<Asset>(): (ID, ID, test_scenario::Scenario) {
-        let (alice_ramm_id, bob_ramm_id, scenario_val) = double_add_asset<Asset>();
+        let (alice_ramm_id, bob_ramm_id, mut scenario_val) = double_add_asset<Asset>();
         let scenario = &mut scenario_val;
 
         initialize_ramm(alice_ramm_id, ALICE, scenario);
@@ -459,10 +459,10 @@ module ramm_sui::ramm_tests {
     #[expected_failure(abort_code = ramm::ENotAdmin)]
     /// Check that setting a new fee collecting address with the wrong `RAMMAdminCap` will fail.
     fun set_fee_collector_admin_cap_mismatch() {
-        let (_alice_ramm_id, bob_ramm_id, scenario_val) = double_initialize<BTC>();
+        let (_alice_ramm_id, bob_ramm_id, mut scenario_val) = double_initialize<BTC>();
         let scenario = &mut scenario_val;
         {
-            let bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
+            let mut bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
             let alice_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ALICE);
 
             ramm::set_fee_collector(&mut bob_ramm, &alice_admin_cap, ALICE);
@@ -478,10 +478,10 @@ module ramm_sui::ramm_tests {
     #[expected_failure(abort_code = ramm::ENotAdmin)]
     /// Check that setting minimum trade amounts with the wrong `RAMMAdminCap` will fail.
     fun set_minimum_trade_amount_admin_cap_mismatch() {
-        let (_alice_ramm_id, bob_ramm_id, scenario_val) = double_initialize<BTC>();
+        let (_alice_ramm_id, bob_ramm_id, mut scenario_val) = double_initialize<BTC>();
         let scenario = &mut scenario_val;
         {
-            let bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
+            let mut bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
             let alice_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ALICE);
 
             ramm::set_minimum_trade_amount<BTC>(&mut bob_ramm, &alice_admin_cap, 1);
@@ -496,7 +496,7 @@ module ramm_sui::ramm_tests {
     #[test]
     /// Check that setting minimum trade amounts works as intended.
     fun set_minimum_trade_amount_test() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         let _aggr_id = test_util::create_write_share_aggregator(scenario, 2780245000000, 8, false, 100);
@@ -512,7 +512,7 @@ module ramm_sui::ramm_tests {
         {
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
             let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ADMIN);
-            let ramm = test_scenario::take_shared<RAMM>(scenario); 
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario); 
 
             let btc_aggr = test_scenario::take_shared<Aggregator>(scenario);
 
@@ -545,7 +545,7 @@ module ramm_sui::ramm_tests {
     #[test]
     /// Check that changing the fee collection address works as intended.
     fun set_fee_collector_test() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         // Create the RAMM
@@ -557,7 +557,7 @@ module ramm_sui::ramm_tests {
         // Retrieve RAMM and caps from storage, and add above assets to it
         {
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
 
             test_utils::assert_eq(ramm::get_fee_collector(&ramm), ADMIN);
             ramm::set_fee_collector(&mut ramm, &admin_cap, ALICE);
@@ -576,10 +576,10 @@ module ramm_sui::ramm_tests {
     #[expected_failure(abort_code = ramm::ENotAdmin)]
     /// Check that enabling deposits for an asset with the wrong `RAMMAdminCap` will fail.
     fun enable_deposits_admin_cap_mismatch() {
-        let (_alice_ramm_id, bob_ramm_id, scenario_val) = double_initialize<BTC>();
+        let (_alice_ramm_id, bob_ramm_id, mut scenario_val) = double_initialize<BTC>();
         let scenario = &mut scenario_val;
         {
-            let bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
+            let mut bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
             let alice_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ALICE);
 
             ramm::enable_deposits<BTC>(&mut bob_ramm, &alice_admin_cap);
@@ -595,10 +595,10 @@ module ramm_sui::ramm_tests {
     #[expected_failure(abort_code = ramm::ENotAdmin)]
     /// Check that disabling deposits for an asset with the wrong `RAMMAdminCap` will fail.
     fun disable_deposits_admin_cap_mismatch() {
-        let (_alice_ramm_id, bob_ramm_id, scenario_val) = double_initialize<BTC>();
+        let (_alice_ramm_id, bob_ramm_id, mut scenario_val) = double_initialize<BTC>();
         let scenario = &mut scenario_val;
         {
-            let bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
+            let mut bob_ramm = test_scenario::take_shared_by_id<RAMM>(scenario, bob_ramm_id);
             let alice_admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ALICE);
 
             ramm::disable_deposits<BTC>(&mut bob_ramm, &alice_admin_cap);
@@ -613,7 +613,7 @@ module ramm_sui::ramm_tests {
     #[test]
     /// Check that setting (enabling/disabling) deposit status works as intended.
     fun set_deposit_status_test() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         let _aggr_id = test_util::create_write_share_aggregator(scenario, 2780245000000, 8, false, 100);
@@ -629,7 +629,7 @@ module ramm_sui::ramm_tests {
         {
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
             let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ADMIN);
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
 
             let btc_aggr = test_scenario::take_shared<Aggregator>(scenario);
 
@@ -663,7 +663,7 @@ module ramm_sui::ramm_tests {
     #[test]
     /// Check that setting a new address of an `Aggregator` works as intended.
     fun set_aggregator_address_test() {
-        let scenario_val = test_scenario::begin(ADMIN);
+        let mut scenario_val = test_scenario::begin(ADMIN);
         let scenario = &mut scenario_val;
 
         let fst_aggr_addr: address =
@@ -687,7 +687,7 @@ module ramm_sui::ramm_tests {
         {
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, ADMIN);
             let new_asset_cap = test_scenario::take_from_address<RAMMNewAssetCap>(scenario, ADMIN);
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
 
             // Add the asset with the address of the first created aggregator.
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, object::id_from_address(fst_aggr_addr));
@@ -719,7 +719,7 @@ module ramm_sui::ramm_tests {
     #[test]
     /// Check that setting a new address of an `Aggregator` works as intended.
     fun get_pool_state_test() {
-        let (ramm_id, _, _, _, scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
+        let (ramm_id, _, _, _, mut scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         test_scenario::next_tx(scenario, ALICE);

--- a/ramm-sui/tests/test_util.move
+++ b/ramm-sui/tests/test_util.move
@@ -51,7 +51,7 @@ module ramm_sui::test_util {
     ///
     /// If the numbers are farther apart than `eps`, the assertion fails.
     public(friend) fun assert_eq_eps(t1: u256, t2: u256, eps: u256) {
-        let sub: u256;
+        let mut sub: u256;
         if (t1 > t2) { sub = t1 - t2; } else { sub = t2 - t1; };
         if (!(sub <= eps)) {
             test_utils::print(b"Assertion failed:");
@@ -70,12 +70,12 @@ module ramm_sui::test_util {
     /// Coins used in testing - for coins to be using in the test*net*, see the `ramm-misc` package.
     /// --------------------------------------------------------------------------------------------
 
-    struct BTC has drop {}
-    struct ETH has drop {}
-    struct MATIC has drop {}
-    struct SOL has drop {}
-    struct USDC has drop {}
-    struct USDT has drop {}
+    public struct BTC has drop {}
+    public struct ETH has drop {}
+    public struct MATIC has drop {}
+    public struct SOL has drop {}
+    public struct USDC has drop {}
+    public struct USDT has drop {}
 
     /// Decimal places of this module's BTC coin type.
     public(friend) fun btc_dec_places(): u8 {
@@ -132,7 +132,7 @@ module ramm_sui::test_util {
     /// ----------------
 
     /// For testing use only - one time witness for aggregator creation.
-    struct SecretKey has drop {}
+    public struct SecretKey has drop {}
 
     #[test_only]
     /// Create an `Aggregator` for testing
@@ -192,7 +192,7 @@ module ramm_sui::test_util {
         timestamp: u64
     ): Aggregator {
         let ctx = test_scenario::ctx(scenario);
-        let aggr = create_aggregator_for_testing(ctx);
+        let mut aggr = create_aggregator_for_testing(ctx);
         set_aggregator_value(val, scale, neg, &mut aggr, timestamp, ctx);
         aggr
     }
@@ -236,7 +236,7 @@ module ramm_sui::test_util {
         initial_asset_liquidity: VecMap<u8, u64>,
         sender: address
     ): (ID, ID, ID, test_scenario::Scenario) {
-        let scenario_val = test_scenario::begin(sender);
+        let mut scenario_val = test_scenario::begin(sender);
         let scenario = &mut scenario_val;
 
         // Create a clock for testing, and immediately share it to avoid
@@ -272,7 +272,7 @@ module ramm_sui::test_util {
         // The pattern is the same - create the required aggregators, add their respective assets to
         // the RAMM, initialize it, etc
         let ramm_id = {
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let rid = object::id(&ramm);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, sender);
@@ -357,7 +357,7 @@ module ramm_sui::test_util {
         initial_asset_liquidity: VecMap<u8, u64>,
         sender: address
     ): (ID, ID, ID, ID, test_scenario::Scenario) {
-        let scenario_val = test_scenario::begin(sender);
+        let mut scenario_val = test_scenario::begin(sender);
         let scenario = &mut scenario_val;
 
         // Create a clock for testing, and immediately share it to avoid
@@ -400,7 +400,7 @@ module ramm_sui::test_util {
         // The pattern is the same - create the required aggregators, add their respective assets to
         // the RAMM, initialize it, etc
         let ramm_id = {
-            let ramm = test_scenario::take_shared<RAMM>(scenario);
+            let mut ramm = test_scenario::take_shared<RAMM>(scenario);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let rid = object::id(&ramm);
             let admin_cap = test_scenario::take_from_address<RAMMAdminCap>(scenario, sender);
@@ -510,18 +510,18 @@ module ramm_sui::test_util {
         sender: address,
         initial_asset_liquidity: VecMap<u8, u64>
     ): (ID, ID, ID, test_scenario::Scenario) {
-        let asset_prices: VecMap<u8, u128> = vec_map::empty();
+        let mut asset_prices: VecMap<u8, u128> = vec_map::empty();
             vec_map::insert(&mut asset_prices, 0, 27_800_000000000);
             vec_map::insert(&mut asset_prices, 1, 1_880_000000000);
-        let asset_price_scales: VecMap<u8, u8> = vec_map::empty();
+        let mut asset_price_scales: VecMap<u8, u8> = vec_map::empty();
             vec_map::insert(&mut asset_price_scales, 0, 9);
             vec_map::insert(&mut asset_price_scales, 1, 9);
-        let asset_minimum_trade_amounts: VecMap<u8, u64> = vec_map::empty();
+        let mut asset_minimum_trade_amounts: VecMap<u8, u64> = vec_map::empty();
             // min trade amount for BTC is 0.0001 BTC
             vec_map::insert(&mut asset_minimum_trade_amounts, 0, (btc_factor() / 10000 as u64));
             // min trade amount for ETH is 0.001 ETH
             vec_map::insert(&mut asset_minimum_trade_amounts, 1, (eth_factor() / 1000 as u64));
-        let asset_decimal_places: VecMap<u8, u8> = vec_map::empty();
+        let mut asset_decimal_places: VecMap<u8, u8> = vec_map::empty();
             vec_map::insert(&mut asset_decimal_places, 0, 8);
             vec_map::insert(&mut asset_decimal_places, 1, 8);
 
@@ -542,7 +542,7 @@ module ramm_sui::test_util {
     /// * 1000 units of starting liquidity in all assets
     public(friend) fun create_ramm_test_scenario_btc_eth_with_liq(sender: address)
         : (ID, ID, ID, test_scenario::Scenario) {
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
             vec_map::insert(&mut initial_asset_liquidity, 0, (1000 * btc_factor() as u64));
             vec_map::insert(&mut initial_asset_liquidity, 1, (1000 * eth_factor() as u64));
 
@@ -559,7 +559,7 @@ module ramm_sui::test_util {
     /// * no starting liquidity
     public(friend) fun create_ramm_test_scenario_btc_eth_no_liq(sender: address)
         : (ID, ID, ID, test_scenario::Scenario) {
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
             vec_map::insert(&mut initial_asset_liquidity, 0, 0);
             vec_map::insert(&mut initial_asset_liquidity, 1, 0);
 
@@ -585,19 +585,19 @@ module ramm_sui::test_util {
         sender: address,
         initial_asset_liquidity: VecMap<u8, u64>
     ): (ID, ID, ID, ID, test_scenario::Scenario) {
-        let asset_prices: VecMap<u8, u128> = vec_map::empty();
+        let mut asset_prices: VecMap<u8, u128> = vec_map::empty();
         vec_map::insert(&mut asset_prices, 0, 27_800_000000000);
         vec_map::insert(&mut asset_prices, 1, 1_880_000000000);
         vec_map::insert(&mut asset_prices, 2, 20_000000000);
-        let asset_price_scales: VecMap<u8, u8> = vec_map::empty();
+        let mut asset_price_scales: VecMap<u8, u8> = vec_map::empty();
         vec_map::insert(&mut asset_price_scales, 0, 9);
         vec_map::insert(&mut asset_price_scales, 1, 9);
         vec_map::insert(&mut asset_price_scales, 2, 9);
-        let asset_minimum_trade_amounts: VecMap<u8, u64> = vec_map::empty();
+        let mut asset_minimum_trade_amounts: VecMap<u8, u64> = vec_map::empty();
         vec_map::insert(&mut asset_minimum_trade_amounts, 0, (btc_factor() / 10000 as u64));
         vec_map::insert(&mut asset_minimum_trade_amounts, 1, (eth_factor() / 1000 as u64));
         vec_map::insert(&mut asset_minimum_trade_amounts, 2, (sol_factor() / 10 as u64));
-        let asset_decimal_places: VecMap<u8, u8> = vec_map::empty();
+        let mut asset_decimal_places: VecMap<u8, u8> = vec_map::empty();
         vec_map::insert(&mut asset_decimal_places, 0, 8);
         vec_map::insert(&mut asset_decimal_places, 1, 8);
         vec_map::insert(&mut asset_decimal_places, 2, 8);
@@ -621,7 +621,7 @@ module ramm_sui::test_util {
     public(friend) fun create_ramm_test_scenario_btc_eth_sol_with_liq(
         sender: address,
     ): (ID, ID, ID, ID, test_scenario::Scenario) {
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
             vec_map::insert(&mut initial_asset_liquidity, 0, (10 * btc_factor() as u64));
             vec_map::insert(&mut initial_asset_liquidity, 1, (100 * eth_factor() as u64));
             vec_map::insert(&mut initial_asset_liquidity, 2, (10000 * sol_factor() as u64));
@@ -638,7 +638,7 @@ module ramm_sui::test_util {
     public(friend) fun create_ramm_test_scenario_btc_eth_sol_no_liq(
         sender: address,
     ): (ID, ID, ID, ID, test_scenario::Scenario) {
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
             vec_map::insert(&mut initial_asset_liquidity, 0, 0);
             vec_map::insert(&mut initial_asset_liquidity, 1, 0);
             vec_map::insert(&mut initial_asset_liquidity, 2, 0);
@@ -657,19 +657,19 @@ module ramm_sui::test_util {
     /// Create an ETH/USDT pool with the parameters from the whitepaper's second
     /// practical example.
     public(friend) fun create_ramm_test_scenario_eth_usdt(sender: address): (ID, ID, ID, Scenario) {
-        let asset_prices: VecMap<u8, u128> = vec_map::empty();
+        let mut asset_prices: VecMap<u8, u128> = vec_map::empty();
         vec_map::insert(&mut asset_prices, 0, 2_000_000000000);
         vec_map::insert(&mut asset_prices, 1, 1_000000000);
-        let asset_price_scales: VecMap<u8, u8> = vec_map::empty();
+        let mut asset_price_scales: VecMap<u8, u8> = vec_map::empty();
         vec_map::insert(&mut asset_price_scales, 0, 9);
         vec_map::insert(&mut asset_price_scales, 1, 9);
-        let asset_minimum_trade_amounts: VecMap<u8, u64> = vec_map::empty();
+        let mut asset_minimum_trade_amounts: VecMap<u8, u64> = vec_map::empty();
         vec_map::insert(&mut asset_minimum_trade_amounts, 0, 1 * (eth_factor() as u64) / 1000);
         vec_map::insert(&mut asset_minimum_trade_amounts, 1, 1 * (usdt_factor() as u64));
-        let asset_decimal_places: VecMap<u8, u8> = vec_map::empty();
+        let mut asset_decimal_places: VecMap<u8, u8> = vec_map::empty();
         vec_map::insert(&mut asset_decimal_places, 0, eth_dec_places());
         vec_map::insert(&mut asset_decimal_places, 1, usdt_dec_places());
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
         vec_map::insert(&mut initial_asset_liquidity, 0, 500 * (eth_factor() as u64));
         vec_map::insert(&mut initial_asset_liquidity, 1, 900_000 * (usdt_factor() as u64));
 
@@ -687,23 +687,23 @@ module ramm_sui::test_util {
     /// Create an ETH/MATIC/USDT pool with the parameters from the whitepaper's first
     /// practical example.
     public(friend) fun create_ramm_test_scenario_eth_matic_usdt(sender: address): (ID, ID, ID, ID, Scenario) {
-        let asset_prices: VecMap<u8, u128> = vec_map::empty();
+        let mut asset_prices: VecMap<u8, u128> = vec_map::empty();
         vec_map::insert(&mut asset_prices, 0, 1_800_000000000);
         vec_map::insert(&mut asset_prices, 1, 1_200000000);
         vec_map::insert(&mut asset_prices, 2, 1_000000000);
-        let asset_price_scales: VecMap<u8, u8> = vec_map::empty();
+        let mut asset_price_scales: VecMap<u8, u8> = vec_map::empty();
         vec_map::insert(&mut asset_price_scales, 0, 9);
         vec_map::insert(&mut asset_price_scales, 1, 9);
         vec_map::insert(&mut asset_price_scales, 2, 9);
-        let asset_minimum_trade_amounts: VecMap<u8, u64> = vec_map::empty();
+        let mut asset_minimum_trade_amounts: VecMap<u8, u64> = vec_map::empty();
         vec_map::insert(&mut asset_minimum_trade_amounts, 0, 1 * (eth_factor() as u64) / 1000);
         vec_map::insert(&mut asset_minimum_trade_amounts, 1, 1 * (matic_factor() as u64));
         vec_map::insert(&mut asset_minimum_trade_amounts, 2, 1 * (usdt_factor() as u64));
-        let asset_decimal_places: VecMap<u8, u8> = vec_map::empty();
+        let mut asset_decimal_places: VecMap<u8, u8> = vec_map::empty();
         vec_map::insert(&mut asset_decimal_places, 0, eth_dec_places());
         vec_map::insert(&mut asset_decimal_places, 1, matic_dec_places());
         vec_map::insert(&mut asset_decimal_places, 2, usdt_dec_places());
-        let initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
+        let mut initial_asset_liquidity: VecMap<u8, u64> = vec_map::empty();
         vec_map::insert(&mut initial_asset_liquidity, 0, 200 * (eth_factor() as u64));
         vec_map::insert(&mut initial_asset_liquidity, 1, 200_000 * (matic_factor() as u64));
         vec_map::insert(&mut initial_asset_liquidity, 2, 400_000 * (usdt_factor() as u64));

--- a/ramm-sui/tests/volatility2_tests.move
+++ b/ramm-sui/tests/volatility2_tests.move
@@ -39,7 +39,7 @@ module ramm_sui::volatility2_tests {
     ///     - 0.1% base trading fee
     /// - protocol fee is 30% of the total, so 3.03%
     fun trade_amount_in_2_volatility_test() {
-        let (ramm_id, eth_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         // First part of the test: the RAMM's admin, who also happens to have administrative rights
@@ -49,8 +49,8 @@ module ramm_sui::volatility2_tests {
 
         {
             let clock = test_scenario::take_shared<Clock>(scenario);
-            let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
-            let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
+            let mut eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
+            let mut usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
 
             let current_timestamp: u64 = clock::timestamp_ms(&clock);
 
@@ -106,7 +106,7 @@ module ramm_sui::volatility2_tests {
         test_scenario::next_tx(scenario, ALICE);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
@@ -220,7 +220,7 @@ module ramm_sui::volatility2_tests {
     ///     - 0.1% base trading fee
     /// - protocol fee is 30% of the total, so 3.03%
     fun trade_amount_out_2_volatility_test() {
-        let (ramm_id, eth_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         // First part of the test: the RAMM's admin, who also happens to have administrative rights
@@ -230,8 +230,8 @@ module ramm_sui::volatility2_tests {
 
         {
             let clock = test_scenario::take_shared<Clock>(scenario);
-            let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
-            let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
+            let mut eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
+            let mut usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
 
             let current_timestamp: u64 = clock::timestamp_ms(&clock);
 
@@ -290,7 +290,7 @@ module ramm_sui::volatility2_tests {
         // from the ETH/USDT RAMM, with the new price of 2100 USDT per ETH.
         test_scenario::next_tx(scenario, ALICE);
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
@@ -411,15 +411,15 @@ module ramm_sui::volatility2_tests {
     /// Inbound/outbound deposit*LP token amounts should not be affected by volatility, but they should
     /// still update the RAMM's internal volatility data after each asset's respective oracle query.
     fun liquidity_deposit_2_volatility_test() {
-        let (ramm_id, btc_ag_id, eth_ag_id, scenario_val) = test_util::create_ramm_test_scenario_btc_eth_no_liq(ADMIN);
+        let (ramm_id, btc_ag_id, eth_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_btc_eth_no_liq(ADMIN);
         let scenario = &mut scenario_val;
 
         test_scenario::next_tx(scenario, ADMIN);
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
-            let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
-            let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
+            let mut btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
+            let mut eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
 
             let current_timestamp: u64 = clock::timestamp_ms(&clock);
 
@@ -591,7 +591,7 @@ module ramm_sui::volatility2_tests {
     /// - 5% volatility for outbound asset, plus
     /// - 0.4% base liquidity withdrawal fee
     fun liquidity_withdrawal_2_volatility_test() {
-        let (ramm_id, eth_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         // First part of the test: the RAMM's admin, who also happens to have administrative rights
@@ -601,8 +601,8 @@ module ramm_sui::volatility2_tests {
 
         {
             let clock = test_scenario::take_shared<Clock>(scenario);
-            let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
-            let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
+            let mut eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
+            let mut usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
 
             let current_timestamp: u64 = clock::timestamp_ms(&clock);
 
@@ -660,7 +660,7 @@ module ramm_sui::volatility2_tests {
         test_scenario::next_tx(scenario, ADMIN);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);

--- a/ramm-sui/tests/volatility3_tests.move
+++ b/ramm-sui/tests/volatility3_tests.move
@@ -42,7 +42,7 @@ module ramm_sui::volatility3_tests {
     /// The uninvolved asset's volatility should not affect the result, but should still lead
     /// to an update of that asset's volatility data.
     fun trade_amount_in_3_volatility_test() {
-        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         // First part of the test: the RAMM's admin, who also happens to have administrative rights
@@ -52,9 +52,9 @@ module ramm_sui::volatility3_tests {
 
         {
             let clock = test_scenario::take_shared<Clock>(scenario);
-            let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
-            let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
-            let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
+            let mut eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
+            let mut matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
+            let mut usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
 
             let current_timestamp: u64 = clock::timestamp_ms(&clock);
 
@@ -130,7 +130,7 @@ module ramm_sui::volatility3_tests {
         test_scenario::next_tx(scenario, ALICE);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
@@ -252,7 +252,7 @@ module ramm_sui::volatility3_tests {
     /// The uninvolved asset's volatility should not affect the result, but its pricing/volatility
     /// data should still be updated.
     fun trade_amount_out_3_volatility_test() {
-        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
+        let (ramm_id, eth_ag_id, matic_ag_id, usdt_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_eth_matic_usdt(ADMIN);
         let scenario = &mut scenario_val;
 
         // First part of the test: the RAMM's admin, who also happens to have administrative rights
@@ -262,9 +262,9 @@ module ramm_sui::volatility3_tests {
 
         {
             let clock = test_scenario::take_shared<Clock>(scenario);
-            let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
-            let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
-            let usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
+            let mut eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
+            let mut matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
+            let mut usdt_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, usdt_ag_id);
 
             let current_timestamp: u64 = clock::timestamp_ms(&clock);
 
@@ -343,7 +343,7 @@ module ramm_sui::volatility3_tests {
         // from the ETH/USDT RAMM, with the new price of 1960 USDT per ETH.
         test_scenario::next_tx(scenario, ALICE);
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
             let matic_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, matic_ag_id);
@@ -469,16 +469,16 @@ module ramm_sui::volatility3_tests {
     ///
     /// The uninvolved assets' volatility/pricing should also be updated.
     fun liquidity_deposit_3_volatility_test() {
-        let (ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val) = test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ADMIN);
+        let (ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_btc_eth_sol_no_liq(ADMIN);
         let scenario = &mut scenario_val;
 
         test_scenario::next_tx(scenario, ADMIN);
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
-            let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
-            let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
-            let sol_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, sol_ag_id);
+            let mut btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
+            let mut eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
+            let mut sol_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, sol_ag_id);
 
             let current_timestamp: u64 = clock::timestamp_ms(&clock);
 
@@ -690,7 +690,7 @@ module ramm_sui::volatility3_tests {
     /// - 5% volatility for outbound asset, plus
     /// - 0.4% base liquidity withdrawal fee
     fun liquidity_withdrawal_3_volatility_test() {
-        let (ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, scenario_val) = test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ADMIN);
+        let (ramm_id, btc_ag_id, eth_ag_id, sol_ag_id, mut scenario_val) = test_util::create_ramm_test_scenario_btc_eth_sol_with_liq(ADMIN);
         let scenario = &mut scenario_val;
 
         // First part of the test: the RAMM's admin, who also happens to have administrative rights
@@ -700,9 +700,9 @@ module ramm_sui::volatility3_tests {
 
         {
             let clock = test_scenario::take_shared<Clock>(scenario);
-            let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
-            let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
-            let sol_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, sol_ag_id);
+            let mut btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
+            let mut eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);
+            let mut sol_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, sol_ag_id);
 
             let current_timestamp: u64 = clock::timestamp_ms(&clock);
 
@@ -779,7 +779,7 @@ module ramm_sui::volatility3_tests {
         test_scenario::next_tx(scenario, ADMIN);
 
         {
-            let ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
+            let mut ramm = test_scenario::take_shared_by_id<RAMM>(scenario, ramm_id);
             let clock = test_scenario::take_shared<Clock>(scenario);
             let btc_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, btc_ag_id);
             let eth_aggr = test_scenario::take_shared_by_id<Aggregator>(scenario, eth_ag_id);


### PR DESCRIPTION
Closes #6.

It seems that `edition = 2024.alpha` does not yet support `enum`s - that feature is in development. See MystenLabs/sui#15086

Since they (`enum`s) would have been the principal reason for a migration, and the net benefit elseways isn't sufficient to justify it, I will be rolling it back for now until `2024.rc1` is released, hopefully with that feature.